### PR TITLE
feat: scope PR reviews to incremental diff on synchronize events

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -28,6 +28,15 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Set diff scope
+        shell: bash
+        run: |
+          if [ "${{ github.event_name }}" = "synchronize" ]; then
+            echo 'DIFF_INSTRUCTION=This is a synchronize event (new commits were pushed to the PR). Start by running `git diff ${{ github.event.before }} ${{ github.event.after }}` to see only the changes in this push.\n\nAfter inspecting the diff, use your judgment: if the changes touch foundational or widely-shared code — such as base classes, abstract classes, interfaces, shared utilities, type definitions, schemas, authentication/authorization logic, or configuration files that many other files depend on — then also run `gh pr diff ${{ github.event.pull_request.number }}` to get the full PR context before completing your review.\n\nIf the changes are isolated (self-contained features, local logic, tests, docs), review only the incremental changes and do not re-review files already covered in previous commits.' >> $GITHUB_ENV
+          else
+            echo 'DIFF_INSTRUCTION=Use `gh pr diff ${{ github.event.pull_request.number }}` to retrieve the full PR diff.' >> $GITHUB_ENV
+          fi
+
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
@@ -37,7 +46,9 @@ jobs:
           prompt: |
             Review the pull request in repository ${{ github.repository }} (#${{ github.event.pull_request.number }}).
 
-            Use `gh pr diff ${{ github.event.pull_request.number }}` to retrieve the diff, then evaluate the changes across these dimensions:
+            ${{ env.DIFF_INSTRUCTION }}
+
+            Evaluate the changes across these dimensions:
 
             1. **Code quality** — clarity, naming, structure, duplication, and adherence to the language's idiomatic style
             2. **Security** — injection risks, secrets in code, insecure dependencies, unsafe deserialization, improper auth checks

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -8,5 +8,6 @@
 - [x] Write root README
 - [ ] Initialize git and push to GitHub (`cbeaulieu-gt/github-actions`)
 - [ ] Cut `v1.0.0` tag and create floating `v1` pointer
+- [x] Implement smart synchronize diff scoping in PR review workflow and composite action
 - [ ] Test PR review action in a consuming repo
 - [ ] Test tag-claude action in a consuming repo

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -21,6 +21,15 @@ runs:
       with:
         fetch-depth: 0
 
+    - name: Set diff scope
+      shell: bash
+      run: |
+        if [ "${{ github.event_name }}" = "synchronize" ]; then
+          echo 'DIFF_INSTRUCTION=This is a synchronize event (new commits were pushed to the PR). Start by running `git diff ${{ github.event.before }} ${{ github.event.after }}` to see only the changes in this push.\n\nAfter inspecting the diff, use your judgment: if the changes touch foundational or widely-shared code — such as base classes, abstract classes, interfaces, shared utilities, type definitions, schemas, authentication/authorization logic, or configuration files that many other files depend on — then also run `gh pr diff ${{ github.event.pull_request.number }}` to get the full PR context before completing your review.\n\nIf the changes are isolated (self-contained features, local logic, tests, docs), review only the incremental changes and do not re-review files already covered in previous commits.' >> $GITHUB_ENV
+        else
+          echo 'DIFF_INSTRUCTION=Use `gh pr diff ${{ github.event.pull_request.number }}` to retrieve the full PR diff.' >> $GITHUB_ENV
+        fi
+
     - uses: anthropics/claude-code-action@v1
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
@@ -30,7 +39,9 @@ runs:
         prompt: |
           Review the pull request in repository ${{ github.repository }} (#${{ github.event.pull_request.number }}).
 
-          Use `gh pr diff ${{ github.event.pull_request.number }}` to retrieve the diff, then evaluate the changes across these dimensions:
+          ${{ env.DIFF_INSTRUCTION }}
+
+          Evaluate the changes across these dimensions:
 
           1. **Code quality** — clarity, naming, structure, duplication, and adherence to the language's idiomatic style
           2. **Security** — injection risks, secrets in code, insecure dependencies, unsafe deserialization, improper auth checks


### PR DESCRIPTION
## Summary

- On `synchronize` events, Claude now inspects only the commits in the new push (`git diff before..after`) instead of re-reviewing the full PR diff
- Claude is given explicit criteria to escalate to a full review when changes touch foundational code (base classes, interfaces, shared utilities, schemas, auth logic) that may have downstream impact on other files
- `opened` and `reopened` events are unchanged — they continue to review the full PR diff

## Test plan

- [x] Open a PR and verify full review runs on `opened`
- [ ] Push a follow-up commit with isolated changes and verify only those files are reviewed
- [ ] Push a follow-up commit touching a base class or shared utility and verify Claude escalates to a full PR review

🤖 Generated with [Claude Code](https://claude.com/claude-code)