### PR TITLE
fix: add id-token: write permission for claude-code-action OIDC auth

### DIFF
--- a/.github/workflows/ci-failure.yaml
+++ b/.github/workflows/ci-failure.yaml
@@ -30,6 +30,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   diagnose:

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -23,6 +23,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/claude-tag-respond.yml
+++ b/.github/workflows/claude-tag-respond.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       issues: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Problem

`claude-code-action@v1` uses OIDC to exchange the `CLAUDE_CODE_OAUTH_TOKEN`, which requires `id-token: write` in the workflow permissions. Without it the action fails with:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
```

## Fix

Added `id-token: write` to all three workflows that use `claude-code-action`:
- `claude-pr-review.yml`
- `claude-tag-respond.yml`
- `ci-failure.yaml`

> **Note for composite action users**: if you use `pr-review/action.yml` or `tag-claude/action.yml` directly (not via the reusable workflows), you must add `id-token: write` to your own workflow's permissions block.

## Test plan

- [ ] Verify PR review workflow completes without the OIDC error on a new PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)