### PR TITLE
feat: add Claude PR review workflow (dogfood)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,19 @@
+name: PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Permissions must be at workflow level (not job level) for reusable workflow calls.
+# pull_request events default to pull-requests: none, so write must be granted explicitly.
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    # Use @main so this repo always runs the latest local version of the workflow
+    # rather than a pinned release that would need updating after every change.
+    uses: cbeaulieu-gt/github-actions/.github/workflows/claude-pr-review.yml@main
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `.github/workflows/pr-review.yml` so pull requests to this repo are automatically reviewed by Claude — using the library on itself.

Uses `@main` rather than a pinned version tag so the repo always runs the latest local version of the review workflow without needing to cut a new release first.

## Test plan

- [ ] Verify Claude posts a review comment on this PR after merge of a subsequent PR
- [ ] Confirm `CLAUDE_CODE_OAUTH_TOKEN` secret is set on the repo

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)