### PR TITLE
chore: add CLAUDE.md and bump version to v1.2.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,7 +54,7 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ## Versioning
 
-- `v1.1.0` — pinned tag for reproducible builds
+- `v1.2.0` — pinned tag for reproducible builds
 - `v1` — floating tag, always points to latest `v1.x.x`
 - Internal workflows use `@main` so they pick up local changes without a release cut
 


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` — architecture and conventions guide for Claude Code, covering the dual workflow/composite-action pattern, key GitHub Actions permission gotchas, versioning strategy, and required secrets
- Bumps version reference in `CLAUDE.md` from `v1.1.0` → `v1.2.0`

## What's in v1.2.0 (since v1.1.0)

- **#18** — `tag-claude` security controls: author_association gate, `authorized_users` allowlist, per-user concurrency
- **#18** — DRY auth refactor: `check-auth` composite action; reusable workflow delegates to composite
- **#22** — Dogfood PR review workflow for this repo
- **This PR** — `CLAUDE.md` conventions guide

## After merge

Move `v1` floating tag and cut `v1.2.0`:

```bash
git tag -f v1.2.0 main
git tag -f v1 main
git push origin v1.2.0 --force
git push origin v1 --force
```

Then create a GitHub release against `v1.2.0`.

closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)