### PR TITLE
fix(pr-review): add gh to allowed_tools and raise default max_turns to 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Optional inputs:
 ```yaml
     with:
       model: claude-opus-4-5   # default: claude-sonnet-4-5
-      max_turns: '20'          # default: 10
+      max_turns: '20'          # default: 15
 ```
 
 ### Tag Claude

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -12,7 +12,7 @@ inputs:
   max_turns:
     description: 'Maximum number of Claude turns'
     required: false
-    default: '10'
+    default: '15'
 
 runs:
   using: composite
@@ -37,6 +37,7 @@ runs:
         github_token: ${{ github.token }}
         use_sticky_comment: true
         track_progress: true
+        allowed_tools: 'Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr view:*)'
         claude_args: --max-turns ${{ inputs.max_turns }} --model ${{ inputs.model }}
         prompt: |
           Review the pull request in repository ${{ github.repository }} (#${{ github.event.pull_request.number }}).


### PR DESCRIPTION
## Problem

PR review consistently fails on first run with `error_max_turns` and `permission_denials_count: 1`.

Two compounding issues:

1. **`gh` is not in the allowed tools list** — the prompt tells Claude to run `gh pr diff <N>` and `gh pr review` for inline comments, but neither is permitted. Claude gets denied, then burns extra turns finding an alternative approach.
2. **No headroom at `max_turns: 10`** — after the denial detour, Claude hits the turn limit before finishing the review.

Reruns succeed because the sticky comment already has partial content — Claude does less work and stays within 10 turns.

## Changes

- Add `Bash(gh pr diff:*)`, `Bash(gh pr review:*)`, `Bash(gh pr view:*)` to `allowed_tools` in `pr-review/action.yml`
- Raise default `max_turns` from `10` → `15`
- Update README to reflect new default

## Test

Merge this and open a fresh PR against a repo using `@v1` (or `@main`). The first run should complete without hitting `error_max_turns`.

fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)