### PR TITLE
security: fix command injection in apply-fix via env vars and post-apply path validation

### DIFF
--- a/apply-fix/action.yml
+++ b/apply-fix/action.yml
@@ -60,8 +60,9 @@ runs:
 
     - name: Push fix
       shell: bash
-      run: |
-        BRANCH=$(gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.ref')
-        git push origin HEAD:$BRANCH
       env:
+        PR_NUMBER: ${{ inputs.pr_number }}
         GH_TOKEN: ${{ inputs.github_token }}
+      run: |
+        BRANCH=$(gh api repos/${{ github.repository }}/pulls/"$PR_NUMBER" --jq '.head.ref')
+        git push origin HEAD:"$BRANCH"


### PR DESCRIPTION
## Summary

Two vulnerabilities fixed in `apply-fix/action.yml`.

### Vulnerability 1 — Command injection via inline interpolation

`${{ inputs.fix_diff }}` and `${{ inputs.fix_description }}` were interpolated directly into `run:` shell strings. GitHub Actions substitutes these expressions before bash parses the string, so any shell metacharacter in the input (semicolons, backticks, `$()`) becomes live shell syntax. Anyone with `workflow_dispatch` access could execute arbitrary commands with the `GH_PAT` token in scope.

**Fix:** Route both values through `env:` block variables (`DIFF_CONTENT`, `FIX_DESC`). Bash receives them as environment variables — they are never evaluated as code. The diff is written to `/tmp/fix.patch` via `printf '%s' "$DIFF_CONTENT"` to avoid word-splitting.

### Vulnerability 2 — Bypassable `.github/` protected path check

The path guard parsed raw diff text for `+++ b/` lines *before* `git apply`. An attacker could include a fake `+++ b/not-github/something` header to pass the grep while having `git apply` write to `.github/` via a different path encoding.

**Fix:** Apply the diff first, then check `git diff --cached --name-only` (authoritative — git itself reports what was staged). If `.github/` files are detected, `git reset HEAD` rolls back the staged changes before exiting.

## Test plan

- [ ] Valid diff applies and commits successfully
- [ ] Diff targeting `.github/` paths is rejected after apply (staged changes rolled back)
- [ ] Input containing shell metacharacters (`$(id)`, backticks, semicolons) does not execute arbitrary commands
- [ ] actionlint passes

closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)