### PR TITLE
fix(lint): eliminate duplicate runs on PR pushes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+  pull_request:
 
 jobs:
   actionlint:


### PR DESCRIPTION
## Summary

- Scopes the `push` trigger to `main` only, so `actionlint` no longer runs twice when a commit is pushed to a PR branch

**Before:**
```yaml
on: [push, pull_request]
```

**After:**
```yaml
on:
  push:
    branches: [main]
  pull_request:
```

`pull_request` already covers every push to a PR branch — the extra `push` trigger was redundant and caused a duplicate run on every PR synchronize event.

Fixes #50

## Test plan

- [ ] Push a commit to this PR branch and confirm only one lint check appears in the checks list
- [ ] Merge to `main` and confirm the lint job runs once post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

*Attribution: Claude Sonnet 4.6*