### PR TITLE
feat(tag-claude): make max_turns optional, omit flag when unset

### DIFF
--- a/tag-claude/action.yml
+++ b/tag-claude/action.yml
@@ -32,7 +32,7 @@ inputs:
   max_turns:
     description: 'Maximum number of Claude turns'
     required: false
-    default: '10'
+    default: ''
 
 runs:
   using: composite
@@ -47,10 +47,21 @@ runs:
     - uses: actions/checkout@v4
       if: steps.authz.outputs.authorized == 'true'
 
+    - name: Build claude args
+      id: args
+      if: steps.authz.outputs.authorized == 'true'
+      shell: bash
+      run: |
+        ARGS="--model ${{ inputs.model }}"
+        if [ -n "${{ inputs.max_turns }}" ]; then
+          ARGS="$ARGS --max-turns ${{ inputs.max_turns }}"
+        fi
+        echo "claude_args=$ARGS" >> "$GITHUB_OUTPUT"
+
     - uses: anthropics/claude-code-action@v1
       if: steps.authz.outputs.authorized == 'true'
       with:
         claude_code_oauth_token: ${{ inputs.claude_code_oauth_token }}
         github_token: ${{ github.token }}
         trigger_phrase: ${{ inputs.trigger_phrase }}
-        claude_args: --max-turns "${{ inputs.max_turns }}" --model "${{ inputs.model }}"
+        claude_args: ${{ steps.args.outputs.claude_args }}


### PR DESCRIPTION
## Summary

- Removes the hardcoded `default: '10'` from the `max_turns` input — it now defaults to empty string
- Adds a `Build claude args` shell step that conditionally appends `--max-turns` only when `max_turns` is non-empty
- Both the build step and the `claude-code-action` step are gated on `steps.authz.outputs.authorized == 'true'` so they skip on unauthorized triggers

## Why

`tag-claude` is primarily used to respond to `@claude` mentions when automated PR review hits its turn limit. Injecting `--max-turns 10` unconditionally meant Claude would hit the same ceiling and fail again. Callers who want a cap can still pass `max_turns` explicitly.

## Test plan

- [ ] Trigger `@claude` on a PR without passing `max_turns` — confirm `--max-turns` does not appear in the run logs
- [ ] Trigger `@claude` on a PR with `max_turns: 5` passed by the caller workflow — confirm `--max-turns 5` is present in the run logs
- [ ] Trigger from an unauthorized user — confirm all three post-auth steps are skipped

closes #54