### PR TITLE
fix: align claude-tag-respond max_turns default with tag-claude action

### DIFF
--- a/.github/workflows/claude-tag-respond.yml
+++ b/.github/workflows/claude-tag-respond.yml
@@ -30,7 +30,7 @@ on:
         description: 'Maximum number of Claude turns'
         type: string
         required: false
-        default: '10'
+        default: ''
 
 # NOTE: The consuming repo's workflow must declare the event triggers
 # (issue_comment, pull_request_review_comment, etc.) — this reusable


### PR DESCRIPTION
## Summary

- Removes the hardcoded `default: '10'` from `max_turns` in the reusable workflow, replacing it with `''` to match `tag-claude/action.yml`

## Why

`tag-claude/action.yml` uses `default: ''` for `max_turns` so that when unset, `--max-turns` is omitted from `claude_args` and `claude-code-action` falls back to its own internal default. The workflow wrapper still had `default: '10'`, silently overriding that intent for all consumers — they'd always get 10 turns even without explicitly configuring anything.

fixes #58

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)