### PR TITLE
feat(tag-claude): post incomplete-run warning when Claude hits turn limit

### DIFF
--- a/tag-claude/action.yml
+++ b/tag-claude/action.yml
@@ -77,10 +77,17 @@ runs:
       # shellcheck disable=SC2016
       env:
         GH_TOKEN: ${{ github.token }}
+        # GitHub populates issue.number for both issue comments and PR review comments,
+        # so gh issue comment works in both contexts without branching on event type.
         ISSUE_NUMBER: ${{ github.event.issue.number }}
         MAX_TURNS: ${{ inputs.max_turns }}
         RUN_START_TIME: ${{ env.RUN_START_TIME }}
       run: |
+        if [ -z "$ISSUE_NUMBER" ]; then
+          echo "No issue number found in event context, skipping incomplete-run warning"
+          exit 0
+        fi
+
         # Skip the warning if Claude already posted a comment during this run.
         # Filter by author (github-actions[bot]) and timestamp to avoid false positives
         # from prior runs or comments by other automation on the same issue/PR.


### PR DESCRIPTION
## Summary

- Adds a "Record run start time" step before `claude-code-action` so the warning step has a lower-bound timestamp for filtering comments
- Adds a "Post incomplete-run warning" step that fires on `failure()` when the user was authorized
- Warning is suppressed if Claude already posted a comment during this run (checked via `gh issue view --json comments | jq`)
- Warning is suppressed if the trigger was unauthorized (gated by `steps.authz.outputs.authorized == 'true'`)
- Uses `github.event.issue.number` + `gh issue comment` — GitHub populates `issue.number` for both issue comments and PR review comments, so this works in both contexts without branching
- `max_turns` is mentioned in the warning only when the caller explicitly set it

## Why

`tag-claude` silently failed when Claude hit the turn limit — the user saw a red workflow run but no comment explaining what happened or what to do next. This mirrors the same pattern already shipped in `pr-review/action.yml`.

## Test plan

- [ ] Trigger `@claude` on an issue where Claude hits the turn limit — warning comment should appear
- [ ] Trigger `@claude` on a PR where Claude hits the turn limit — warning comment should appear (via `issue.number`)
- [ ] Trigger `@claude` where Claude completes successfully — no warning comment
- [ ] Trigger `@claude` from an unauthorized user — no warning comment

closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)