### PR TITLE
fix(lint-failure): raise max_turns default from 10 to 20

### DIFF
--- a/.github/workflows/claude-lint-fix.yml
+++ b/.github/workflows/claude-lint-fix.yml
@@ -25,7 +25,7 @@ on:
         description: 'Maximum number of Claude turns'
         type: string
         required: false
-        default: '10'
+        default: '20'
       auto_apply:
         description: 'If true, Claude will commit and push a high-confidence fix automatically'
         type: boolean

--- a/lint-failure/action.yml
+++ b/lint-failure/action.yml
@@ -25,7 +25,7 @@ inputs:
   max_turns:
     description: 'Maximum number of Claude turns'
     required: false
-    default: '10'
+    default: '20'
 
 runs:
   using: composite


### PR DESCRIPTION
## Summary

- Raises `max_turns` default from `10` to `20` in both `lint-failure/action.yml` and `claude-lint-fix.yml`
- The minimum happy-path tool call sequence (read 3 files, post comment, write patch, apply, commit, get branch, push, append note) already consumes 9–10 turns — 10 leaves zero margin for retries or multi-step reasoning
- 20 provides 2× headroom while keeping lint-fix tighter than the 30–60 range used by `pr-review`
- Both files updated together — the workflow exposes its own `max_turns` input that consumers can override, so both defaults must stay in sync

## Test plan

- [ ] Trigger a lint failure on a PR and confirm Claude completes the full cycle (diagnosis comment + auto-apply if enabled) without hitting the turn limit
- [ ] Confirm `num_turns` in the execution log is below 20

closes #70

---
> Generated with [Claude Code](https://claude.ai/claude-code)