### PR TITLE
docs: add consolidated permissions reference and fix job-level permissions in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ All actions authenticate using a `CLAUDE_CODE_OAUTH_TOKEN` secret.
 
 ---
 
+## Permissions Reference
+
+> **Critical:** GitHub ignores `permissions:` declared at the job level when a job calls a reusable workflow (`uses:`). You **must** declare permissions at the **workflow level** (top-level `permissions:` key, outside of `jobs:`). Job-level permissions are silently ignored in this context, which can cause cryptic 403 errors or missing write access at runtime.
+
+The table below shows the minimum required permissions for each consumer workflow file. Copy the exact block shown into the top level of your workflow (after `on:`, before `jobs:`).
+
+| Workflow | Trigger | Required `permissions:` block |
+|---|---|---|
+| PR Review | `pull_request` | `contents: read`<br>`pull-requests: write` |
+| Tag Claude | `issue_comment` + `pull_request_review_comment` | `contents: write`<br>`issues: write`<br>`pull-requests: write` |
+| Claude Lint Fix | `pull_request` (via `needs: [lint]`, `if: failure()`) | `contents: write`<br>`pull-requests: write`<br>`actions: read` |
+| CI Failure Diagnosis | `workflow_run` | `contents: write`<br>`pull-requests: write` |
+
+---
+
 ## Quick Start
 
 The easiest way to consume these actions is via the **reusable workflow** pattern. Add one file to your repo and you're done.
@@ -205,6 +220,20 @@ The `claude-lint-fix` workflow lets consumers drop a single `notify-claude` job 
 ### Consumer usage
 
 ```yaml
+# .github/workflows/lint.yml
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Permissions must be declared at workflow level (not job level) when calling
+# reusable workflows. actions: read is required to fetch failed run logs.
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -22,12 +22,15 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
+# Permissions must be declared at workflow level (not job level).
+# pull_request events default to pull-requests: none — write must be explicit.
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   claude-review:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
     steps:
       - uses: cbeaulieu-gt/github-actions/pr-review@v1
         with:

--- a/tag-claude/README.md
+++ b/tag-claude/README.md
@@ -23,13 +23,16 @@ on:
   pull_request_review_comment:
     types: [created]
 
+# Permissions must be declared at workflow level (not job level).
+# contents: write is required so Claude can push commits when asked.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
   claude-respond:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      issues: write
-      pull-requests: write
     steps:
       - uses: cbeaulieu-gt/github-actions/tag-claude@v1
         with:


### PR DESCRIPTION
## Summary

- Adds a **Permissions Reference** section near the top of `README.md` with a consolidated table mapping each workflow to its exact required `permissions:` block, plus a prominent warning about GitHub silently ignoring job-level permissions when calling reusable workflows
- Fixes the Claude Lint Fix consumer example in `README.md` — was a bare `jobs:` fragment with no `permissions:` block; now a complete workflow with `name:`, `on:`, and the correct workflow-level `permissions:`
- Fixes `tag-claude/README.md` — changes `contents: read` → `contents: write` (write is needed for Claude to push commits) and moves `permissions:` from job level to workflow level
- Fixes `pr-review/README.md` — moves `permissions:` from job level to workflow level (values `contents: read` + `pull-requests: write` were already correct)

closes #74

## Test plan

- [ ] Verify the Permissions Reference table renders correctly in the GitHub README preview
- [ ] Verify the lint-fix consumer example is now a syntactically complete workflow YAML
- [ ] Verify `tag-claude/README.md` shows `contents: write` at workflow level
- [ ] Verify `pr-review/README.md` shows `permissions:` at workflow level (before `jobs:`)
- [ ] Confirm actionlint passes (docs-only change, no workflow files modified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)