### PR TITLE
chore: release v1.7.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ## Versioning
 
-- `v1.6.0` — pinned tag for reproducible builds
+- `v1.7.0` — pinned tag for reproducible builds
 - `v1` — floating tag, always points to latest `v1.x.x`
 
 When changes are released: move both `v1` and the new `v1.x.x` tag to the latest main HEAD and force-push both tags. Create a GitHub release against `v1.x.x`.


### PR DESCRIPTION
## v1.7.0 Release

Updates the pinned version reference in CLAUDE.md. Tags and GitHub release will be created after merge.

### What's in this release (since v1.6.0)

**New features**
- **PR review checkpoint** (#81) — Records a `claude-pr-review:success` commit status after each completed review. On the next `synchronize` run, walks PR commits to find the last reviewed SHA and uses it as the diff base, closing the coverage gap when `cancel-in-progress` cancels a mid-flight run.
- **lint-fix split into diagnose + apply jobs** (#82) — Splits the single lint-fix job into two phases with independent concurrency: `diagnose` (`cancel-in-progress: true`, stateless) and `apply` (`cancel-in-progress: false`, write operation). Patch passed between jobs via artifact. Consumer interface unchanged.
- **cancel-in-progress concurrency** (#76) — Per-PR concurrency blocks on `claude-pr-review` and `claude-lint-fix` so rapid pushes cancel stale runs rather than queuing.

**Bug fixes**
- **SIGPIPE false failure in log fetch** (#80) — `head -c 16000` caused SIGPIPE (exit 141) with `pipefail`, failing the step even when 16KB of logs were captured successfully. Fixed in `lint-failure`, `ci-failure`, and new `lint-diagnose`.
- **PAT for git push re-triggers pr-review** (#77) — `claude-code-action` was receiving `github.token` instead of the PAT, so auto-fix commits went out as `github-actions[bot]` and GitHub suppressed the `synchronize` event. Fixed in `lint-failure` and `ci-failure`.
- **lint-failure max_turns raised to 20** (#71), **allowedTools fixed** (#67), **track_progress disabled** (#65)

**Docs**
- Permissions reference table added to README (#75)
- CLAUDE.md token guidance updated to distinguish read-only vs push use cases

---
*No breaking changes. Consumer workflow interfaces are unchanged.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)