### PR TITLE
refactor(pr-review): migrate inline ${{ }} expressions in Resolve diff base to env block

### DIFF
--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -25,16 +25,18 @@ runs:
       if: github.event.action == 'synchronize'
       id: resolve-diff-base
       shell: bash
-      # shellcheck disable=SC2016
       env:
         GH_TOKEN: ${{ github.token }}
+        GH_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        DIFF_FALLBACK_SHA: ${{ github.event.before }}
       run: |
         # Walk PR commits newest-first (excluding HEAD, which hasn't been reviewed yet)
         # and find the most recent commit carrying a claude-pr-review:success status.
         # Export DIFF_BASE_SHA for use by the "Set diff scope" step.
-        REPO="${{ github.repository }}"
-        PR_NUMBER="${{ github.event.pull_request.number }}"
-        FALLBACK="${{ github.event.before }}"
+        REPO="$GH_REPOSITORY"
+        PR_NUMBER="$PR_NUMBER"
+        FALLBACK="$DIFF_FALLBACK_SHA"
 
         # Fetch the list of PR commit SHAs, oldest-first (GitHub API default), then reverse.
         COMMITS=$(gh api "repos/$REPO/pulls/$PR_NUMBER/commits" \


### PR DESCRIPTION
Moves the three inline `${{ }}` expressions in the `Resolve diff base` step out of the `run:` script and into the step's `env:` block.

**Before:**
```bash
REPO="${{ github.repository }}"
PR_NUMBER="${{ github.event.pull_request.number }}"
FALLBACK="${{ github.event.before }}"
```

**After (`env:` block additions):**
```yaml
GH_REPOSITORY: ${{ github.repository }}
PR_NUMBER: ${{ github.event.pull_request.number }}
DIFF_FALLBACK_SHA: ${{ github.event.before }}
```
**After (run script):**
```bash
REPO="$GH_REPOSITORY"
PR_NUMBER="$PR_NUMBER"
FALLBACK="$DIFF_FALLBACK_SHA"
```

The `# shellcheck disable=SC2016` annotation on this step is also removed since no `${{ }}` expressions remain in the `run:` block.

**Out-of-scope inline expressions noted (not fixed in this PR):** `Set diff scope` (line 83), `Compute effective max_turns` (lines 99, 104), `Check author association` (lines 134-136), `Check PR size` (line 152), `Record review checkpoint` (lines 201, 205).

closes #85
