### PR TITLE
chore: release v1.7.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ## Versioning
 
-- `v1.7.0` — pinned tag for reproducible builds
+- `v1.7.1` — pinned tag for reproducible builds
 - `v1` — floating tag, always points to latest `v1.x.x`
 
 When changes are released: move both `v1` and the new `v1.x.x` tag to the latest main HEAD and force-push both tags. Create a GitHub release against `v1.x.x`.


### PR DESCRIPTION
## v1.7.1 Release

### Bug fixes
- **Template validation fix** (#84, #86) — `pr-review` action was failing to load for all callers with `An expression was expected` at line 82. Root cause: `${{ github.event.action }}` used directly inside a `run:` shell script instead of being bound in the `env:` block. Fixed by moving it to `env:` consistent with every other step in the file.

### Refactor
- **Resolve diff base env cleanup** (#85, #87) — Migrated three remaining inline `${{ }}` expressions in the `Resolve diff base` step to the `env:` block (`GH_REPOSITORY`, `PR_NUMBER`, `DIFF_FALLBACK_SHA`). Removed the now-unnecessary `shellcheck disable=SC2016` annotation from that step.

---
*No breaking changes. Consumer workflow interfaces are unchanged.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)