### PR TITLE
chore: release v1.7.3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ## Versioning
 
-- `v1.7.2` — pinned tag for reproducible builds
+- `v1.7.3` — pinned tag for reproducible builds
 - `v1` — floating tag, always points to latest `v1.x.x`
 
 When changes are released: move both `v1` and the new `v1.x.x` tag to the latest main HEAD and force-push both tags. Create a GitHub release against `v1.x.x`.


### PR DESCRIPTION
Bumps version reference in `CLAUDE.md` to `v1.7.3`.

## What's in this release

- **fix(pr-review)**: use heredoc delimiter format for multiline `DIFF_INSTRUCTION` in `$GITHUB_ENV` — fixes deterministic failure on every `synchronize` event (#93)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)