### PR TITLE
chore: release v1.8.0

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ## Versioning
 
-- `v1.7.3` — pinned tag for reproducible builds
+- `v1.8.0` — pinned tag for reproducible builds
 - `v1` — floating tag, always points to latest `v1.x.x`
 
 When changes are released: move both `v1` and the new `v1.x.x` tag to the latest main HEAD and force-push both tags. Create a GitHub release against `v1.x.x`.


### PR DESCRIPTION
Bumps version reference in `CLAUDE.md` to `v1.8.0`.

## What's in this release

### ✨ New feature — GitHub App token support

Replaces long-lived `GH_PAT` personal access tokens with short-lived GitHub App tokens generated via `actions/create-github-app-token@v1`. App tokens show a distinct bot identity (e.g. `my-app[bot]`) in commits and comments, trigger downstream `synchronize` events, and expire automatically.

**Changes:**
- `apply-fix`, `lint-apply`, `lint-diagnose`, `lint-failure` — new `app_id` + `app_private_key` inputs; token validation with `::error::` on missing auth; `::debug::` logging on token source
- `ci-failure.yaml` — inline App token generation with `continue-on-error` PAT fallback
- `claude-lint-fix.yml`, `apply-fix.yml` — new secrets threaded through
- `README.md` — updated secrets tables, GitHub App setup guide, troubleshooting section
- `CLAUDE.md` — updated token selection guidance

`GH_PAT` continues to work as a deprecated fallback and will be removed in v2. Closes #73.

## Consumer migration

Add two new repository secrets — `APP_ID` and `APP_PRIVATE_KEY` — and update your caller workflows. See the README migration guide for details.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)