### PR TITLE
docs: slack-notify action design spec (refs #122)

### DIFF
--- a/docs/superpowers/specs/2026-04-08-slack-notify-design.md
+++ b/docs/superpowers/specs/2026-04-08-slack-notify-design.md
@@ -25,12 +25,13 @@ Delivered as a **composite action only** (no reusable workflow wrapper). Consume
 | Input | Default | Description |
 |---|---|---|
 | `workflow_name` | `${{ github.workflow }}` | Name of the workflow that ran |
+| `repository` | `${{ github.repository }}` | Repository name in `owner/repo` format |
 | `run_url` | `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}` | Link to the workflow run |
 | `branch` | `${{ github.ref_name }}` | Branch name |
 | `pr_number` | `''` | PR number, if applicable |
 | `commit_sha` | `${{ github.sha }}` | Commit SHA |
 | `actor` | `${{ github.actor }}` | Who triggered the workflow |
-| `duration` | `''` | Workflow duration string (e.g., `"2m 34s"`), consumer-calculated |
+| `duration` | `''` | Workflow duration — any human-readable string; displayed as-is in the context block. Consumer calculates (e.g., `"2m 34s"`, `"3 minutes"`, `"00:02:34"`). |
 
 ### Optional Inputs — Claude Context
 
@@ -42,9 +43,9 @@ Delivered as a **composite action only** (no reusable workflow wrapper). Consume
 
 ### Outputs
 
-| Output | Description |
-|---|---|
-| `message_ts` | Slack message timestamp (for threading replies) |
+None in v1.
+
+> **Note on threading replies.** Slack incoming webhooks return plain-text `ok` on success, not JSON with a `ts` / `message_ts` field. Message-timestamp outputs (which would enable threaded replies) require migrating the action to the Slack Web API (`chat.postMessage`, OAuth-token auth instead of webhook URL) — a different auth model with different consumer tradeoffs. If threading becomes a requirement, open a new spec discussion rather than bolting it on.
 
 ## Message Layout
 
@@ -113,8 +114,8 @@ No `src/`, no `dist/`, no `package.json`, no Node.js source — this matches the
 - **`lib/build-payload.sh` is the unit-testable seam** — reads all inputs from env vars (`STATUS`, `WORKFLOW_NAME`, `CLAUDE_SUMMARY`, etc.), constructs the Block Kit JSON via `jq`, and prints it to stdout. Pure function in the bash sense — no network, no side effects, exit code 0 on success. This is what `bats` tests pin.
 - **`jq` builds the JSON** — `jq -n` with `--arg` for each user-provided input constructs the Block Kit structure declaratively. This is safer than string-concatenating JSON and gives correct escaping of `"`, `\`, newlines, and control characters for free. Conditional blocks (e.g. the Claude section) are composed via `jq` conditionals (`if $summary != "" then … else empty end`).
 - **`curl` posts the webhook** — one POST with `Content-Type: application/json`, a 10-second `--max-time`, and `--fail-with-body` so HTTP 2xx is distinguishable from non-2xx. No Slack SDK needed; incoming webhooks accept a bare JSON payload.
+- **URL construction** — the commit-SHA link is built as `${{ github.server_url }}/${{ github.repository }}/commit/<commit_sha>`; the PR link as `${{ github.server_url }}/${{ github.repository }}/pull/<pr_number>`. Both values enter `action.yml` as env vars and are passed into `jq` via `--arg` bindings, never interpolated into the `jq` expression string — same injection-safety pattern as all other user-provided fields.
 - **No new dependencies** — `bash`, `jq`, and `curl` are pre-installed on every GitHub-hosted `ubuntu-latest` runner. `bats` runs in CI but does not ship as part of the action.
-- **`message_ts` output handling** — Slack's incoming webhooks return a `message_ts` on successful POST. The action captures the response body via `curl -o` and extracts `.ts` (or `.message_ts` — verify against current Slack docs at implementation time) with `jq -r`, then writes it to `$GITHUB_OUTPUT`. If Slack ever returns a response without `message_ts`, the output is set to an empty string rather than failing.
 - **No build step** — the repo has no `package.json`, no `ncc`, no `dist/check` workflow (the `build-check.yml` referenced in the pre-revert original is gone). An addition of this action should not re-introduce any of those. If a future feature genuinely needs TypeScript, it opens a new spec discussion — the default is no.
 
 ## Error Handling
@@ -151,9 +152,8 @@ The testable seam is `lib/build-payload.sh` — it reads env vars, emits JSON to
 - **JSON injection attempt** — input containing `","malicious":"1` (trying to break out of the JSON string) is safely escaped by `jq --arg` and appears literally in the `text` field; the output JSON structure is not corrupted (validate with `jq` parsing — any corruption fails the parse).
 - **Invalid status** — `status=broken` produces a failure-colored message (`red`) with a warning printed to stderr; exit code is 0.
 - **All optional fields empty** — minimal payload: header + context + one action button; no Claude block; no PR-related fields in context block.
-- **Timestamp extraction helper** — unit-test the `curl` response → `message_ts` extraction as its own small shell function if the logic is non-trivial; otherwise inline-test it via the integration layer.
 
-Bats runs via the existing `test.yml` workflow — add a new job `slack-notify-bats` that runs `bats slack-notify/tests/build-payload.bats`. `shellcheck` also runs against `slack-notify/lib/*.sh` and the action.yml's embedded shell blocks.
+Bats runs via a new `slack-notify-bats` job — either added to the existing `lint.yml` workflow (which already runs on every push/PR and owns `actionlint`) or to a new `test.yml` created alongside. The implementer picks whichever fits cleanest when the implementation lands; spec is pattern-level, not workflow-file-level. `shellcheck` also runs against `slack-notify/lib/*.sh` and the action.yml's embedded shell blocks.
 
 ### Integration Tests
 

--- a/docs/superpowers/specs/2026-04-08-slack-notify-design.md
+++ b/docs/superpowers/specs/2026-04-08-slack-notify-design.md
@@ -1,7 +1,9 @@
 # Slack Notify Action — Design Spec
 
-**Date:** 2026-04-08
-**Status:** Approved (brainstorming complete)
+**Date:** 2026-04-08 (original) · revised 2026-04-22
+**Status:** Approved — implementation architecture revised 2026-04-22
+
+> **Revision note (2026-04-22):** The original spec targeted the repo's then-current TypeScript-plus-`ncc` composite-action pattern. PR [#128](https://github.com/cbeaulieu-gt/github-actions/pull/128) reverted that entire architecture, returning the repo to pure-bash composite actions with no `src/`, no `dist/`, no `package.json`. Sections §"Action Architecture" (formerly §"TypeScript Architecture"), §"Error Handling", and §"Testing Strategy" have been rewritten for the bash + `jq` pattern that matches the current `apply-fix/`, `check-auth/`, and `lint-failure/` actions. All design decisions above the implementation chapter (inputs, outputs, message layout, graceful degradation, non-blocking failure) are unchanged and remain approved.
 
 ## Overview
 
@@ -90,72 +92,76 @@ Slack attachment color bar: green for success, red for failure, grey for cancell
 >
 > [View Run]
 
-## TypeScript Architecture
+## Action Architecture
 
 ### File Structure
 
 ```
-src/slack-notify/
-├── index.ts              # Entry point — reads inputs, calls buildPayload, posts to webhook
-├── payload.ts            # Pure function: inputs → Slack Block Kit JSON
-└── types.ts              # Input types and Slack Block Kit type definitions
-
-src/__tests__/slack-notify/
-├── payload.test.ts       # Unit tests for payload construction
-└── index.test.ts         # Integration tests (mocked fetch + @actions/core)
-
 slack-notify/
-├── action.yml            # Composite action definition
-└── dist/
-    └── index.js          # ncc bundle (built, not hand-written)
+├── action.yml                  # Composite action definition — declares inputs/outputs + orchestrates steps
+├── lib/
+│   └── build-payload.sh        # Builds Slack Block Kit JSON from env vars; emits to stdout
+└── tests/
+    └── build-payload.bats      # bats unit tests — asserts against the emitted JSON via jq
 ```
+
+No `src/`, no `dist/`, no `package.json`, no Node.js source — this matches the current `apply-fix/`, `check-auth/`, and `lint-failure/` composite-action pattern and is consistent with the repo's CLAUDE.md declaration that this is a pure GitHub Actions project.
 
 ### Design Decisions
 
-- **`payload.ts` is pure** — takes a typed input object, returns a Slack payload object. No side effects, no I/O. All Block Kit construction and conditional logic lives here. Fully unit-testable.
-- **`index.ts` is thin glue** — reads `@actions/core` inputs, calls `buildPayload()`, posts via `fetch()`, sets outputs. ~20 lines of orchestration.
-- **No new dependencies** — uses native `fetch` (Node 20+) and `@actions/core` (already in repo). No Slack SDK needed; incoming webhooks are a simple POST with JSON.
-- **Build integration** — new `ncc build` entry appended to `package.json`'s `build` script. `build-check.yml` CI already verifies `dist/` freshness.
+- **`action.yml` orchestrates** — declares the composite action using `using: composite` (see `apply-fix/action.yml` for reference); its shell steps pass inputs into env vars, invoke `lib/build-payload.sh` to produce the payload, and `curl`-POST to the webhook. Per the repo convention, any `${{ }}` expression that ends up inside a single-quoted shell string must carry a `shellcheck disable=SC2016` comment.
+- **`lib/build-payload.sh` is the unit-testable seam** — reads all inputs from env vars (`STATUS`, `WORKFLOW_NAME`, `CLAUDE_SUMMARY`, etc.), constructs the Block Kit JSON via `jq`, and prints it to stdout. Pure function in the bash sense — no network, no side effects, exit code 0 on success. This is what `bats` tests pin.
+- **`jq` builds the JSON** — `jq -n` with `--arg` for each user-provided input constructs the Block Kit structure declaratively. This is safer than string-concatenating JSON and gives correct escaping of `"`, `\`, newlines, and control characters for free. Conditional blocks (e.g. the Claude section) are composed via `jq` conditionals (`if $summary != "" then … else empty end`).
+- **`curl` posts the webhook** — one POST with `Content-Type: application/json`, a 10-second `--max-time`, and `--fail-with-body` so HTTP 2xx is distinguishable from non-2xx. No Slack SDK needed; incoming webhooks accept a bare JSON payload.
+- **No new dependencies** — `bash`, `jq`, and `curl` are pre-installed on every GitHub-hosted `ubuntu-latest` runner. `bats` runs in CI but does not ship as part of the action.
+- **`message_ts` output handling** — Slack's incoming webhooks return a `message_ts` on successful POST. The action captures the response body via `curl -o` and extracts `.ts` (or `.message_ts` — verify against current Slack docs at implementation time) with `jq -r`, then writes it to `$GITHUB_OUTPUT`. If Slack ever returns a response without `message_ts`, the output is set to an empty string rather than failing.
+- **No build step** — the repo has no `package.json`, no `ncc`, no `dist/check` workflow (the `build-check.yml` referenced in the pre-revert original is gone). An addition of this action should not re-introduce any of those. If a future feature genuinely needs TypeScript, it opens a new spec discussion — the default is no.
 
 ## Error Handling
 
 ### Webhook Failures
-- Non-2xx response from Slack → `core.warning()` with status code and response body. Does **not** fail the step or job.
-- Network timeout → 10-second fetch timeout, same warning behavior.
-- Rationale: notification failure should never break CI.
+- Non-2xx response from Slack → emit `::warning::Slack webhook returned HTTP <code>: <body>` via GitHub workflow commands (echo to stdout). Step exits 0 — notification failure never breaks CI.
+- Network timeout → `curl --max-time 10` exits non-zero; the shell step traps the exit code, emits a `::warning::` with the curl error, and exits 0.
+- Rationale: notification failure should never break CI. The only way this action fails the job is an input-validation error (see below).
 
 ### Input Validation
-- Missing `webhook_url` → `core.setFailed()`. Config error, fail fast.
-- Missing `status` → `core.setFailed()`. Config error, fail fast.
-- Invalid `status` value (not `success`/`failure`/`cancelled`) → treat as `failure` with `core.warning()`.
-- Empty optional inputs → omit corresponding Block Kit sections. No "undefined" or blank fields.
+- Missing `webhook_url` → `echo "::error::webhook_url is required"` + `exit 1`. Config error, fail fast.
+- Missing `status` → `echo "::error::status is required (expected: success|failure|cancelled)"` + `exit 1`. Config error, fail fast.
+- Invalid `status` value (not `success`/`failure`/`cancelled`) → treat as `failure` and emit `::warning::unknown status '<value>' — treating as failure`. Does not fail the step.
+- Empty optional inputs → `jq` conditionals omit the corresponding Block Kit sections (`if $summary != "" then … else empty end`). No "undefined" or blank fields.
 
 ### Payload Safety
-- **Size limit:** Slack webhooks cap text fields at 3,000 characters. If `claude_summary` exceeds 2,500 characters, truncate with `…(truncated)` suffix.
-- **Special characters:** Escape `&`, `<`, `>` in user-provided text (`claude_summary`, `workflow_name`) for Slack mrkdwn safety.
+- **Size limit:** Slack webhooks cap text fields at 3,000 characters. Before calling `jq`, truncate `$CLAUDE_SUMMARY` to 2,500 chars and append `…(truncated)` if the input exceeded the limit. Implementation: a short bash test using `${#CLAUDE_SUMMARY}` + parameter expansion.
+- **Special characters & injection safety:** All user-provided text (`claude_summary`, `workflow_name`, `branch`, etc.) is passed into `jq` via `--arg` bindings — never interpolated into the `jq` expression string. This gives correct JSON escaping for free (quotes, backslashes, newlines, control chars) and is immune to template-injection tricks in comment bodies or input values. Slack mrkdwn-specific escaping (`&` → `&amp;`, `<` → `&lt;`, `>` → `&gt;`) is applied inside `jq` via `gsub` before emitting text fields.
 
 ## Testing Strategy
 
-### Unit Tests (`payload.test.ts`)
-- Success/failure/cancelled messages — correct Block Kit structure, color, emoji
-- With PR context — "View PR" button present, PR link in context block
-- With Claude context — Claude block with summary, confidence badge, action taken
-- Without Claude context — Claude block entirely absent
-- Claude summary truncation — 3,000-char input truncated to 2,500 with suffix
-- Special character escaping — `&`, `<`, `>` properly escaped
-- Invalid status — treated as failure without crash
-- All optional fields empty — clean minimal message
+### Unit Tests (`tests/build-payload.bats`)
 
-### Integration Tests (`index.test.ts`)
-- Mock `@actions/core` (getInput/setOutput/setFailed/warning) and global `fetch`
-- Happy path — valid inputs, 200 response → `message_ts` output set
-- Webhook failure — 400 response → `core.warning()`, step does not fail
-- Network error — fetch rejection → warning, no crash
-- Missing required input — no webhook_url → `core.setFailed()`
+The testable seam is `lib/build-payload.sh` — it reads env vars, emits JSON to stdout, and has no network or filesystem side effects. Each bats test sets up the env, runs the script, and asserts against the emitted JSON via `jq`. No mocks needed — the script *is* the pure function.
+
+- **Success/failure/cancelled** — assert color bar (`jq '.attachments[0].color'`), header emoji + status text, no Claude block.
+- **With PR context** — assert the "View PR" button block is present and its URL matches the expected `pr_number`.
+- **Without PR context** — assert the action buttons block has only one button (View Run, no View PR).
+- **With Claude context (all fields)** — assert the Claude block exists with expected header text, summary body, confidence badge, and action-taken line.
+- **With Claude context (partial — summary only)** — assert the Claude block exists, confidence + action-taken lines absent.
+- **Without Claude context** — assert the Claude block is completely absent from the JSON (no empty placeholder).
+- **Claude summary truncation** — input of 3,000 chars produces a summary field of exactly 2,500 chars + `…(truncated)` suffix (assert via `jq -r '.attachments[0].blocks[n].text.text | length'`).
+- **Special character escaping** — input `Bug & <script>` produces `Bug &amp; &lt;script&gt;` in the Slack mrkdwn text field.
+- **JSON injection attempt** — input containing `","malicious":"1` (trying to break out of the JSON string) is safely escaped by `jq --arg` and appears literally in the `text` field; the output JSON structure is not corrupted (validate with `jq` parsing — any corruption fails the parse).
+- **Invalid status** — `status=broken` produces a failure-colored message (`red`) with a warning printed to stderr; exit code is 0.
+- **All optional fields empty** — minimal payload: header + context + one action button; no Claude block; no PR-related fields in context block.
+- **Timestamp extraction helper** — unit-test the `curl` response → `message_ts` extraction as its own small shell function if the logic is non-trivial; otherwise inline-test it via the integration layer.
+
+Bats runs via the existing `test.yml` workflow — add a new job `slack-notify-bats` that runs `bats slack-notify/tests/build-payload.bats`. `shellcheck` also runs against `slack-notify/lib/*.sh` and the action.yml's embedded shell blocks.
+
+### Integration Tests
+
+The action is end-to-end-testable only against a real Slack webhook. Dogfooding path: wire a `slack-notify` step behind a non-blocking `if: github.repository == 'cbeaulieu-gt/github-actions'` guard in one of this repo's own workflows, pointing at a maintainer-owned test channel webhook stored as a repo secret. Observe real deliveries; failures appear as `::warning::` annotations in the run log without breaking the job. This is the v1 integration test — more formal mocking infrastructure is out of scope.
 
 ### Not Tested
-- Actual Slack delivery (consumer integration test)
-- Block Kit rendering (Slack's responsibility)
+- Actual Slack delivery (dogfooded on this repo's workflows against a test channel)
+- Block Kit rendering inside the Slack app (Slack's responsibility)
 
 ## Consumer Integration
 

--- a/docs/superpowers/specs/2026-04-08-slack-notify-design.md
+++ b/docs/superpowers/specs/2026-04-08-slack-notify-design.md
@@ -1,0 +1,191 @@
+# Slack Notify Action — Design Spec
+
+**Date:** 2026-04-08
+**Status:** Approved (brainstorming complete)
+
+## Overview
+
+A general-purpose composite action (`slack-notify/`) that sends rich Slack notifications via incoming webhook when any CI workflow completes. Supports both plain CI status messages and Claude-enriched messages that surface diagnosis summaries, confidence levels, and actions taken.
+
+Delivered as a **composite action only** (no reusable workflow wrapper). Consumers add a step to their existing jobs. Each consumer repo provides its own webhook URL pointing to the appropriate project Slack channel.
+
+## Action Interface
+
+### Required Inputs
+
+| Input | Description |
+|---|---|
+| `webhook_url` | Slack incoming webhook URL (passed as a secret) |
+| `status` | Workflow outcome: `success`, `failure`, or `cancelled` |
+
+### Optional Inputs — CI Context
+
+| Input | Default | Description |
+|---|---|---|
+| `workflow_name` | `${{ github.workflow }}` | Name of the workflow that ran |
+| `run_url` | `${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}` | Link to the workflow run |
+| `branch` | `${{ github.ref_name }}` | Branch name |
+| `pr_number` | `''` | PR number, if applicable |
+| `commit_sha` | `${{ github.sha }}` | Commit SHA |
+| `actor` | `${{ github.actor }}` | Who triggered the workflow |
+| `duration` | `''` | Workflow duration string (e.g., `"2m 34s"`), consumer-calculated |
+
+### Optional Inputs — Claude Context
+
+| Input | Description |
+|---|---|
+| `claude_summary` | Free-text summary of what Claude found/did |
+| `confidence` | Claude's confidence level: `high`, `medium`, `low`, or empty |
+| `action_taken` | What Claude did: `patch_applied`, `comment_posted`, `no_action`, or empty |
+
+### Outputs
+
+| Output | Description |
+|---|---|
+| `message_ts` | Slack message timestamp (for threading replies) |
+
+## Message Layout
+
+Uses Slack Block Kit with adaptive sections based on provided inputs.
+
+### Header Block (always)
+Status emoji + workflow name + repo:
+- `✅ build-and-test passed — myorg/myapp`
+- `❌ lint failed — myorg/myapp`
+
+### Context Block (always)
+Compact single line with branch, commit SHA (short, linked), actor, duration (if provided), PR link (if provided):
+- `main • a1b2c3d • @chris • 2m 34s • PR #42`
+
+### Claude Block (only when `claude_summary` is provided)
+- Section header with robot emoji, derived from `action_taken`:
+  - `patch_applied` → `Claude Fix`
+  - `comment_posted` → `Claude Diagnosis`
+  - `no_action` or empty → `Claude Analysis`
+- Summary text as body
+- Confidence badge if provided: `🟢 high` / `🟡 medium` / `🔴 low`
+- Action taken if provided: `Patch applied` / `Comment posted` / `No action`
+
+### Action Button Block (always)
+- "View Run" button linking to `run_url`
+- "View PR" button (only when `pr_number` is provided)
+
+### Color Coding
+Slack attachment color bar: green for success, red for failure, grey for cancelled.
+
+### Example — Failure with Claude Diagnosis
+
+> 🔴 **lint failed — myorg/myapp**
+> `main` • `a1b2c3d` • @chris • 1m 12s • PR #42
+>
+> 🤖 **Claude Lint Diagnosis** · 🟢 high · Patch applied
+> Missing semicolons on lines 14, 28. Applied auto-fix and pushed.
+>
+> [View Run] [View PR #42]
+
+### Example — Plain Success (No Claude Context)
+
+> 🟢 **build-and-test passed — myorg/myapp**
+> `feature-auth` • `f3e4d5c` • @chris • 3m 45s
+>
+> [View Run]
+
+## TypeScript Architecture
+
+### File Structure
+
+```
+src/slack-notify/
+├── index.ts              # Entry point — reads inputs, calls buildPayload, posts to webhook
+├── payload.ts            # Pure function: inputs → Slack Block Kit JSON
+└── types.ts              # Input types and Slack Block Kit type definitions
+
+src/__tests__/slack-notify/
+├── payload.test.ts       # Unit tests for payload construction
+└── index.test.ts         # Integration tests (mocked fetch + @actions/core)
+
+slack-notify/
+├── action.yml            # Composite action definition
+└── dist/
+    └── index.js          # ncc bundle (built, not hand-written)
+```
+
+### Design Decisions
+
+- **`payload.ts` is pure** — takes a typed input object, returns a Slack payload object. No side effects, no I/O. All Block Kit construction and conditional logic lives here. Fully unit-testable.
+- **`index.ts` is thin glue** — reads `@actions/core` inputs, calls `buildPayload()`, posts via `fetch()`, sets outputs. ~20 lines of orchestration.
+- **No new dependencies** — uses native `fetch` (Node 20+) and `@actions/core` (already in repo). No Slack SDK needed; incoming webhooks are a simple POST with JSON.
+- **Build integration** — new `ncc build` entry appended to `package.json`'s `build` script. `build-check.yml` CI already verifies `dist/` freshness.
+
+## Error Handling
+
+### Webhook Failures
+- Non-2xx response from Slack → `core.warning()` with status code and response body. Does **not** fail the step or job.
+- Network timeout → 10-second fetch timeout, same warning behavior.
+- Rationale: notification failure should never break CI.
+
+### Input Validation
+- Missing `webhook_url` → `core.setFailed()`. Config error, fail fast.
+- Missing `status` → `core.setFailed()`. Config error, fail fast.
+- Invalid `status` value (not `success`/`failure`/`cancelled`) → treat as `failure` with `core.warning()`.
+- Empty optional inputs → omit corresponding Block Kit sections. No "undefined" or blank fields.
+
+### Payload Safety
+- **Size limit:** Slack webhooks cap text fields at 3,000 characters. If `claude_summary` exceeds 2,500 characters, truncate with `…(truncated)` suffix.
+- **Special characters:** Escape `&`, `<`, `>` in user-provided text (`claude_summary`, `workflow_name`) for Slack mrkdwn safety.
+
+## Testing Strategy
+
+### Unit Tests (`payload.test.ts`)
+- Success/failure/cancelled messages — correct Block Kit structure, color, emoji
+- With PR context — "View PR" button present, PR link in context block
+- With Claude context — Claude block with summary, confidence badge, action taken
+- Without Claude context — Claude block entirely absent
+- Claude summary truncation — 3,000-char input truncated to 2,500 with suffix
+- Special character escaping — `&`, `<`, `>` properly escaped
+- Invalid status — treated as failure without crash
+- All optional fields empty — clean minimal message
+
+### Integration Tests (`index.test.ts`)
+- Mock `@actions/core` (getInput/setOutput/setFailed/warning) and global `fetch`
+- Happy path — valid inputs, 200 response → `message_ts` output set
+- Webhook failure — 400 response → `core.warning()`, step does not fail
+- Network error — fetch rejection → warning, no crash
+- Missing required input — no webhook_url → `core.setFailed()`
+
+### Not Tested
+- Actual Slack delivery (consumer integration test)
+- Block Kit rendering (Slack's responsibility)
+
+## Consumer Integration
+
+### Basic CI Notification
+
+```yaml
+- name: Notify Slack
+  if: always()
+  uses: cbeaulieu-gt/github-actions/slack-notify@v2
+  with:
+    webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    status: ${{ job.status }}
+```
+
+### Claude-Enriched Notification
+
+```yaml
+- name: Notify Slack
+  if: always()
+  uses: cbeaulieu-gt/github-actions/slack-notify@v2
+  with:
+    webhook_url: ${{ secrets.SLACK_WEBHOOK_URL }}
+    status: ${{ job.status }}
+    pr_number: ${{ github.event.pull_request.number }}
+    claude_summary: ${{ steps.claude.outputs.summary }}
+    confidence: ${{ steps.diagnose.outputs.confidence }}
+    action_taken: ${{ steps.diagnose.outputs.action_taken }}
+```
+
+### Notes
+- `if: always()` is the consumer's choice — the action always fires when invoked
+- Claude-specific inputs gracefully degrade when omitted
+- No changes required to existing actions — this is additive


### PR DESCRIPTION
## Summary

Rescues the slack-notify composite action design spec from a local-only commit (`dbfb5fd`, dated 2026-04-08) that was never pushed to a branch. Lands it under `docs/superpowers/specs/` alongside the CI runtime design spec from PR #131.

**Updated 2026-04-22** — a second commit (`2e67c86`) revises §"Action Architecture", §"Error Handling", and §"Testing Strategy" for the current bash + `jq` + bats composite-action pattern. The original spec was written during the (now-reverted) TypeScript-plus-`ncc` era; all three sections that assumed Node source, `dist/` bundles, and `@actions/core` have been rewritten to target the pattern used by `apply-fix/`, `check-auth/`, and `lint-failure/` today.

Spec status: **Approved — implementation architecture revised 2026-04-22**.

## What's in the spec

- **Action surface** — composite-only (`slack-notify/`), no reusable workflow wrapper. Consumers add a step inside an existing job.
- **Inputs** — `webhook_url` + `status` required; optional CI context (`workflow_name`, `run_url`, `branch`, `pr_number`, `commit_sha`, `actor`, `duration`) all with sensible `github.*` defaults; optional Claude context (`claude_summary`, `confidence`, `action_taken`) for CI-diagnose/apply-fix integration.
- **Per-repo webhooks** — each consumer repo supplies its own webhook URL pointing at the appropriate project Slack channel; no central routing.
- **Implementation pattern** (revised): pure-bash `action.yml` orchestrates; `lib/build-payload.sh` is the testable seam that builds Block Kit JSON via `jq --arg` bindings (injection-safe); `curl` posts with a 10s timeout; `bats` unit-tests the payload builder. No `src/`, no `dist/`, no `package.json`.

## Why a spec-only PR

Same pattern as PR #131 (CI runtime design) — the spec is the approved brainstorming output, and merging it makes it a stable reference for the implementation PR that closes #122. This also prevents losing the document if the local reflog gets GC'd before the implementation lands.

## Scope

- [x] Spec document only — no `slack-notify/action.yml`, no workflow changes
- [ ] Implementation is tracked separately under #122 and follows the current bash + `jq` + bats composite-action pattern (per the revised spec's §"Action Architecture")

## Test plan

- [ ] Reviewer reads the spec end-to-end
- [ ] Reviewer confirms the action surface (inputs/outputs, composite-only delivery, per-repo webhook model) matches what was expected for #122
- [ ] Reviewer confirms the revised implementation pattern (bash + `jq` + bats, no Node source) matches the current repo architecture post-PR #128
- [ ] Any disagreements resolved here before implementation starts

## References

- Scope / implementation issue: #122 (issue body also updated 2026-04-22 to drop TS references)
- Companion spec precedent: PR #131 (CI runtime design)
- Origin commit (cherry-picked onto this branch): `dbfb5fd` from 2026-04-08
- Architectural revert that invalidated the original impl chapter: PR #128

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*