### PR TITLE
chore: ignore .claude/ and node_modules/ (fixes #132)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+# Local dev worktrees created by the `using-git-worktrees` skill
 .worktrees/
+
+# Local Claude Code per-user state (settings, plugin cache, permission grants)
+.claude/
+
+# npm tooling artifacts — this repo has no package.json; node_modules only
+# appears when local skills/tooling drop it in. Never committed.
+node_modules/


### PR DESCRIPTION
## Summary

- Adds `.claude/` and `node_modules/` to `.gitignore` so `git status` in this repo no longer reports them as untracked
- Adds inline comments on each pattern so future contributors understand why each is ignored (the repo has no `package.json`, so `node_modules/` looks out of place without the note)

Fixes #132.

## Why

Before this change, `.gitignore` only covered `.worktrees/`. Any developer using Claude Code in this repo (every contributor) ends up with `.claude/` locally — that directory contains per-user permission grants, plugin cache, and the local settings file. Committing it would leak local config and approval state.

`node_modules/` shows up any time a local skill or tool drops npm packages in — the repo itself has no `package.json`, so it's purely incidental to local tooling and would be a large-noise diff if committed accidentally.

## Test plan

- [ ] `git status` on a fresh checkout with both dirs present reports no untracked paths from `.claude/` or `node_modules/`
- [ ] Diff is the minimal 3-pattern addition (no other `.gitignore` churn)

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*