### PR TITLE
chore: add workflow_dispatch verify-app-secrets diagnostic

### DIFF
--- a/.github/workflows/verify-app-secrets.yml
+++ b/.github/workflows/verify-app-secrets.yml
@@ -1,0 +1,35 @@
+name: Verify App Secrets
+
+# Manually-triggered diagnostic workflow that mints a GitHub App
+# installation token to verify APP_ID and APP_PRIVATE_KEY org-level
+# secrets resolve correctly. Does not call Claude or post comments.
+# Safe to keep long-term as an ops diagnostic, or delete after the
+# one-time verification is complete (refs #148).
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Mint App installation token
+        id: token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
+      - name: Confirm token minted
+        env:
+          TOKEN_PRESENT: ${{ steps.token.outputs.token != '' }}
+        run: |
+          if [ "$TOKEN_PRESENT" = "true" ]; then
+            echo "::notice::App-token resolution succeeded — APP_ID and APP_PRIVATE_KEY org-level secrets resolved correctly. Token minted at $(date -u)."
+          else
+            echo "::error::App-token mint succeeded but token output is empty — unexpected state."
+            exit 1
+          fi


### PR DESCRIPTION
## Verify org-level App secrets

Adds `.github/workflows/verify-app-secrets.yml` — a `workflow_dispatch`-only diagnostic that mints a GitHub App installation token using `APP_ID` and `APP_PRIVATE_KEY`. Used to verify that the org-level secret migration on `glitchwerks` resolved both App secrets correctly.

## Why workflow_dispatch (not issue_comment)

An `issue_comment` self-caller for `claude-tag-respond` would also exercise the App secrets, but it adds a long-lived event listener with non-zero loop risk and per-comment runtime cost. This diagnostic narrows the scope to exactly what needs verifying — does `actions/create-github-app-token@v1` mint a token from these secrets — without invoking Claude or posting comments.

## Test plan

- [ ] `actionlint` passes (only file added is a workflow YAML)
- [ ] After merge: dispatch the workflow via `gh workflow run "Verify App Secrets" --repo glitchwerks/github-actions`
- [ ] Run completes successfully — workflow log shows `::notice::App-token resolution succeeded...`
- [ ] Verify org-level setup checkbox on #148

## Long-term disposition

This workflow is small (~25 lines) and harmless to keep as a permanent ops diagnostic. If you'd rather it be temporary, delete in a follow-up PR after verification.

Refs #148.

---
🤖 Generated by Claude Code on behalf of @cbeaulieu-gt