### PR TITLE
chore: final smoke-test marker for org-only secret resolution

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -19,3 +19,5 @@ GitHub installs an HTTP redirect for the old URL, but `uses:` redirect resolutio
 ## Tags
 
 Existing `v1`, `v1.8.0`, `v2`, `v2.0.0` tags transferred unchanged. A new `v2.0.1` tag will follow this migration with the updated internal references.
+
+<!-- final smoke-test: org-level secrets only, repo-level deleted (refs #148) — 2026-04-29 -->


### PR DESCRIPTION
## Final smoke test — org-level secrets only

Repo-level copies of \`CLAUDE_CODE_OAUTH_TOKEN\`, \`APP_ID\`, and \`APP_PRIVATE_KEY\` have just been deleted. Only org-level secrets remain. This PR triggers \`claude-pr-review\` to confirm \`CLAUDE_CODE_OAUTH_TOKEN\` resolves from the org-level path alone.

This is the second leg of the two-step org-secret verification (refs #148). The first leg verified resolution with both layers present (PR #150, since closed). The third element — \`APP_ID\` / \`APP_PRIVATE_KEY\` org-only — is verified separately by the \`verify-app-secrets\` workflow_dispatch run firing in parallel with this PR.

## Test plan

- [ ] \`claude-pr-review\` workflow runs successfully
- [ ] \`actionlint\` passes
- [ ] \`verify-app-secrets\` workflow_dispatch run (parallel) succeeds
- [ ] After all green: tick org-level setup checkboxes on #148

Refs #148.

---
🤖 Generated by Claude Code on behalf of @cbeaulieu-gt