### PR TITLE
chore: bump actions/create-github-app-token v1 → v3

### DIFF
--- a/.github/workflows/ci-failure.yaml
+++ b/.github/workflows/ci-failure.yaml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - name: Generate App token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/verify-app-secrets.yml
+++ b/.github/workflows/verify-app-secrets.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Mint App installation token
         id: token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/apply-fix/action.yml
+++ b/apply-fix/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Generate App token
       id: app-token
       if: inputs.app_id != '' && inputs.app_private_key != ''
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}

--- a/lint-apply/action.yml
+++ b/lint-apply/action.yml
@@ -18,7 +18,7 @@ runs:
     - name: Generate App token
       id: app-token
       if: inputs.app_id != '' && inputs.app_private_key != ''
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}

--- a/lint-diagnose/action.yml
+++ b/lint-diagnose/action.yml
@@ -50,7 +50,7 @@ runs:
     - name: Generate App token
       id: app-token
       if: inputs.app_id != '' && inputs.app_private_key != ''
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}

--- a/lint-failure/action.yml
+++ b/lint-failure/action.yml
@@ -46,7 +46,7 @@ runs:
     - name: Generate App token
       id: app-token
       if: inputs.app_id != '' && inputs.app_private_key != ''
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}

--- a/tag-claude/action.yml
+++ b/tag-claude/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: Generate App token
       id: app-token
       if: steps.authz.outputs.authorized == 'true' && inputs.app_id != '' && inputs.app_private_key != ''
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@v3
       with:
         app-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}


### PR DESCRIPTION
## Summary

- Bumps `actions/create-github-app-token` from `@v1` to `@v3` across all 7 call sites
- Crosses two major versions: v1 → v2 (2025-04-03) and v2 → v3 (2026-03-14)
- Part of the Node 24 prep campaign (umbrella #154)

## What changed in v2 and v3

### v2.0.0 (2025-04-03) — breaking changes

- **Removed deprecated underscore-style input aliases**: `app_id`, `private_key`, and `skip_token_revoke` were removed. Only the hyphenated forms `app-id` and `private-key` are accepted; they are now required (not optional).
- No output renames — `outputs.token`, `outputs.installation-id`, `outputs.app-slug` are unchanged.

### v3.0.0 (2026-03-14) — breaking changes

- **Node 24 runtime**: Action now runs on Node 24. Requires Actions Runner v2.327.1+ for self-hosted runners; GitHub-hosted runners are unaffected.
- **Proxy handling changed**: Custom HTTP proxy handling removed. `HTTP_PROXY`/`HTTPS_PROXY` env vars now require `NODE_USE_ENV_PROXY=1` to be set on the step. Previously worked automatically.
- No output renames — `outputs.token` remains `outputs.token`.

### v3.1.0 (2026-04-11) — non-breaking additions

- New `client-id` input added as the preferred identifier going forward; `app-id` is soft-deprecated (still works, emits a deprecation notice). No migration required for this PR.
- Permission input updates.

## Why this is safe for this repo

All 7 call sites were individually audited:

| File | Inputs used | Output consumed | Safe? |
|---|---|---|---|
| `.github/workflows/ci-failure.yaml` | `app-id`, `private-key` | `steps.app-token.outputs.token` | Yes — hyphenated inputs, token output unchanged |
| `.github/workflows/verify-app-secrets.yml` | `app-id`, `private-key` | `steps.token.outputs.token` | Yes — same |
| `apply-fix/action.yml` | `app-id`, `private-key` | `steps.app-token.outputs.token` | Yes — same |
| `lint-apply/action.yml` | `app-id`, `private-key` | `steps.app-token.outputs.token` | Yes — same |
| `lint-diagnose/action.yml` | `app-id`, `private-key` | `steps.app-token.outputs.token` | Yes — same |
| `lint-failure/action.yml` | `app-id`, `private-key` | `steps.app-token.outputs.token` | Yes — same |
| `tag-claude/action.yml` | `app-id`, `private-key` | `steps.app-token.outputs.token` | Yes — same |

**v2 break** (removed `app_id`/`private_key`): Not applicable — this repo always used the hyphenated forms.

**v3 break** (proxy via `NODE_USE_ENV_PROXY`): Not applicable — no HTTP proxy is configured in any workflow step.

**v3 runner requirement** (v2.327.1+): All jobs use `runs-on: ubuntu-latest` (GitHub-hosted), which is always on a current runner. No self-hosted runners in this repo.

**Output name `token`**: Confirmed identical in v1, v2, and v3 action.yml — verified directly from `raw.githubusercontent.com`. No consumer reference changes required beyond the pin itself.

## Test plan

- [ ] `actionlint` passes (verified locally — clean before opening PR)
- [ ] `claude-pr-review` passes
- [ ] Post-merge: `verify-app-secrets` workflow_dispatch run succeeds with org-only secrets

refs #155

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt