### PR TITLE
chore: bump actions/upload-artifact v4→v6 and download-artifact v4→v7

### DIFF
--- a/lint-apply/action.yml
+++ b/lint-apply/action.yml
@@ -50,7 +50,7 @@ runs:
         git config user.email "claude-lintfix@users.noreply.github.com"
 
     - name: Download patch artifact
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: lint-patch-${{ github.repository_id }}-${{ inputs.pr_number }}
         path: /tmp/patch

--- a/lint-diagnose/action.yml
+++ b/lint-diagnose/action.yml
@@ -185,7 +185,7 @@ runs:
 
     - name: Upload patch artifact
       if: steps.read-outputs.outputs.has_patch == 'true'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: lint-patch-${{ github.repository_id }}-${{ inputs.pr_number }}
         path: /tmp/lintfix.patch


### PR DESCRIPTION
## Summary

- Paired bump of `actions/upload-artifact` v4 → v6 and `actions/download-artifact` v4 → v7, the second sub-task in the Node 24 prep campaign (umbrella #154)
- v5/v6/v7 are purely Node.js runtime upgrades sharing the same v4-era backend API — no input/output renames and no upload/download compat break
- Two call sites updated: `lint-diagnose/action.yml` (upload) and `lint-apply/action.yml` (download)

## Breaking changes navigated

| Version | Action | Change | Impact on this repo |
|---|---|---|---|
| upload v5.0.0 | upload-artifact | Node.js 24 preliminary support; `@actions/artifact` bumped to v4.0.0 | None — no input/output changes |
| upload v6.0.0 | upload-artifact | Node.js 24 is now the **default** runtime (`runs.using: node24`) | None — no input/output changes |
| download v5.0.0 | download-artifact | **BREAKING**: path inconsistency fix for single artifact downloads **by ID** | Not affected — our call site uses `name:`, not `artifact-ids:` |
| download v6.0.0 | download-artifact | Node.js 24 preliminary support; `@actions/artifact` bumped to v4.0.0 | None — no input/output changes |
| download v7.0.0 | download-artifact | Node.js 24 is now the **default** runtime (`runs.using: node24`) | None — no input/output changes |

## Compat matrix verification

v6-upload artifacts **are** readable by v7-download. Evidence from release notes:

- The last backend-breaking boundary was **v3→v4** (December 2023), which introduced a new artifact API and explicitly stated cross-version incompatibility.
- v5, v6, and v7 release notes for both actions describe **only Node.js runtime changes** — no new artifact format, no new storage backend, no API version bump.
- The `@actions/artifact` package version (v4.0.0) is shared by upload v5/v6 and download v6/v7, confirming they speak the same wire format.

## Per-call-site impact

| File | Action | Pin change | Input/output changes |
|---|---|---|---|
| `lint-diagnose/action.yml:188` | upload-artifact | `@v4` → `@v6` | None — `name:`, `path:`, `retention-days: 1` all unchanged |
| `lint-apply/action.yml:53` | download-artifact | `@v4` → `@v7` | None — `name:`, `path:` all unchanged; uses `name:` not `artifact-ids:` so v5 path-fix is not applicable |

## Test plan

- [x] `actionlint` passes (run against worktree — zero errors)
- [ ] `claude-pr-review` passes
- [ ] No call site uses an input/output that was renamed without being updated

refs #157

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt