### PR TITLE
chore: bump actions/checkout v4 → v5

### DIFF
--- a/.github/workflows/apply-fix.yml
+++ b/.github/workflows/apply-fix.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repo (needed to resolve local composite action)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Apply fix via composite action
         uses: ./apply-fix

--- a/.github/workflows/ci-failure.yaml
+++ b/.github/workflows/ci-failure.yaml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           token: ${{ steps.token.outputs.value }}
           fetch-depth: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: raven-actions/actionlint@v2

--- a/apply-fix/action.yml
+++ b/apply-fix/action.yml
@@ -43,7 +43,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ steps.token.outputs.value }}
         ref: refs/pull/${{ inputs.pr_number }}/head

--- a/lint-apply/action.yml
+++ b/lint-apply/action.yml
@@ -37,7 +37,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ steps.token.outputs.value }}
         fetch-depth: 0

--- a/lint-diagnose/action.yml
+++ b/lint-diagnose/action.yml
@@ -69,7 +69,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ steps.token.outputs.value }}
         fetch-depth: 0

--- a/lint-failure/action.yml
+++ b/lint-failure/action.yml
@@ -65,7 +65,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         token: ${{ steps.token.outputs.value }}
         fetch-depth: 0

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         fetch-depth: 0
 

--- a/tag-claude/action.yml
+++ b/tag-claude/action.yml
@@ -72,7 +72,7 @@ runs:
           exit 1
         fi
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       if: steps.authz.outputs.authorized == 'true'
       with:
         token: ${{ steps.token.outputs.value }}


### PR DESCRIPTION
## Summary

- Bumps `actions/checkout` from `@v4` to `@v5` across all 9 call sites in workflows and composite actions
- Final sub-task (#159) in the Node 24 prep campaign (umbrella #154), following artifact (#155/#156) and upload/download-artifact (#157/#158) bumps
- No input changes or adapations required — this is a pin-only update

## v5 breaking changes

v5.0.0 is a **Node runtime upgrade only** (Node 20 → Node 24). Per the official CHANGELOG and release notes:

- **No inputs were removed or renamed**
- **No input defaults changed** (`fetch-depth`, `persist-credentials`, `ref`, `token`, `submodules` all unchanged)
- **No new required inputs**
- **Minimum runner requirement**: GitHub Actions runner v2.327.1 or newer (all GitHub-hosted runners already meet this)

The sole change is the internal Node runtime version. The action's public API is identical to v4.

## Per-call-site impact

| File | Inputs used | Adaptation needed |
|---|---|---|
| `.github/workflows/apply-fix.yml` | none (bare uses) | none |
| `.github/workflows/ci-failure.yaml` | `token`, `fetch-depth: 0` | none |
| `.github/workflows/lint.yml` | none (bare uses) | none |
| `apply-fix/action.yml` | `token`, `ref`, `fetch-depth: 0` | none |
| `lint-apply/action.yml` | `token`, `fetch-depth: 0`, `ref` | none |
| `lint-diagnose/action.yml` | `token`, `fetch-depth: 0`, `ref` | none |
| `lint-failure/action.yml` | `token`, `fetch-depth: 0`, `ref` | none |
| `pr-review/action.yml` | `fetch-depth: 0` | none |
| `tag-claude/action.yml` | `token` | none |

All 9 call sites are pin-only changes. No behavior changes.

## Test plan

- [ ] `actionlint` passes on all three workflow files (verified locally before push)
- [ ] Lint CI passes on this PR
- [ ] Spot-check: confirm `actions/checkout@v5` resolves correctly in one triggered workflow run after merge

refs #159

🤖 Generated by Claude Code on behalf of @cbeaulieu-gt