### PR TITLE
feat(pr-review): skip review on draft PRs; trigger on ready_for_review

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -6,7 +6,7 @@ on:
   # which prevents auth rejection from claude-code-action. Safe here because no fork code
   # is checked out or executed — Claude only reads the diff via `gh pr diff`.
   pull_request_target:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, ready_for_review]
   # Called by external consumers via `uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2`.
   workflow_call:
     secrets:
@@ -33,6 +33,11 @@ permissions:
 
 jobs:
   review:
+    # Skip while the PR is in draft. The pull_request_target event types include
+    # ready_for_review so a single review fires when the user marks the PR ready.
+    # Issue #174 — avoids redundant API spend + duplicate-finding noise during
+    # iterative draft work (cf. PR #171 which accumulated 14 review runs as a draft).
+    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     concurrency:
       group: claude-pr-review-${{ github.repository }}-${{ github.event.pull_request.number }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ### Actions
 
-- **`pr-review/`** — Reviews PRs via `anthropics/claude-code-action@v1`. On `synchronize` events, diffs only the new commits (`git diff before..after`) and escalates to a full review if foundational code is touched.
+- **`pr-review/`** — Reviews PRs via `anthropics/claude-code-action@v1`. On `synchronize` events, diffs only the new commits (`git diff before..after`) and escalates to a full review if foundational code is touched. Skips review while a PR is in draft; auto-fires once when the PR transitions to ready for review (per #174).
 - **`tag-claude/`** — Responds to `@claude` mentions. Delegates to `./check-auth` first, then calls `claude-code-action` only if authorized.
 - **`check-auth/`** — Authorization primitive. Outputs `authorized=true/false` based on an explicit `authorized_users` allowlist (takes precedence) or `github.event.comment.author_association` (OWNER/MEMBER/COLLABORATOR). Used by `tag-claude/`.
 - **`apply-fix/`** — Validates a unified diff against protected paths (rejects anything touching `.github/`), applies it with `git apply`, commits, and pushes to the PR branch.

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -52,3 +52,26 @@ jobs:
 - The action uses `use_sticky_comment: true`, so repeated runs on the same PR update the existing comment rather than adding new ones.
 - `fetch-depth: 0` is set automatically so Claude has full git history available.
 - Prefer the [reusable workflow](../.github/workflows/claude-pr-review.yml) variant if you don't need to embed this in a more complex job.
+
+## Draft PRs
+
+The reusable workflow at `.github/workflows/claude-pr-review.yml` skips review while a PR is in draft and auto-fires once when the PR transitions from draft to ready for review (the `ready_for_review` event type).
+
+**Why:** iterative draft pushes accumulate redundant review runs that re-flag the same findings. Reviewing a draft on every push wastes API spend, generates duplicate comment noise, and obscures the merge-ready state when the PR is finally ready. Reviewing on the draft → ready transition (and on subsequent pushes once non-draft) gives you exactly one review per meaningful state change.
+
+**For consumers using `workflow_call`:** the draft skip lives in the *caller* workflow, not the reusable workflow itself. To get the same behavior in your repo, add `ready_for_review` to your trigger types and `if: github.event.pull_request.draft == false` to your job. Example:
+
+```yaml
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+jobs:
+  review:
+    if: github.event.pull_request.draft == false
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+```
+
+**To force a review of a draft:** push a commit while the PR is non-draft, or temporarily mark it ready and back to draft (the `ready_for_review` event will fire).

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -59,7 +59,7 @@ The reusable workflow at `.github/workflows/claude-pr-review.yml` skips review w
 
 **Why:** iterative draft pushes accumulate redundant review runs that re-flag the same findings. Reviewing a draft on every push wastes API spend, generates duplicate comment noise, and obscures the merge-ready state when the PR is finally ready. Reviewing on the draft → ready transition (and on subsequent pushes once non-draft) gives you exactly one review per meaningful state change.
 
-**For consumers using `workflow_call`:** the draft skip lives in the *caller* workflow, not the reusable workflow itself. To get the same behavior in your repo, add `ready_for_review` to your trigger types and `if: github.event.pull_request.draft == false` to your job. Example:
+**For consumers using `workflow_call`:** the draft skip is built into the reusable workflow — you don't need to add it yourself. You DO need to add `ready_for_review` to your caller workflow's trigger types so the workflow runs on the draft → ready transition:
 
 ```yaml
 on:
@@ -68,10 +68,13 @@ on:
 
 jobs:
   review:
-    if: github.event.pull_request.draft == false
     uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2
     secrets:
       claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 ```
+
+The reusable workflow's `jobs.review.if: github.event.pull_request.draft == false` skip evaluates against your caller's PR event (`workflow_call` inherits the caller's `github.event` context), so a draft PR will not trigger a review even though your caller job is invoked.
+
+(Optional: if you want to skip the `workflow_call` invocation entirely on drafts to avoid the small dispatch overhead, you can add `if: github.event.pull_request.draft == false` to your caller job too. Cosmetic improvement only — the actual `claude-code-action` invocation is already gated.)
 
 **To force a review of a draft:** push a commit while the PR is non-draft, or temporarily mark it ready and back to draft (the `ready_for_review` event will fire).


### PR DESCRIPTION
## Summary

Stops the Claude PR review workflow from running on draft PRs. Adds `ready_for_review` to the `pull_request_target` trigger types and a job-level `if: github.event.pull_request.draft == false` so the review fires exactly once per meaningful state change.

## Motivation

PR [#171](https://github.com/glitchwerks/github-actions/pull/171) (Phase 2 base image) accumulated 14 separate Claude review runs while in draft. Each run posted a multi-KB comment that re-flagged the same critical finding (word-splitting in `extract-shared.sh`) plus a fresh diff analysis. By the time the PR was actually ready to merge, the thread was buried in stale review comments — and ~$0.30 of API spend had been burned on a single PR.

A draft PR is by definition not ready for review. Reviewing it on every push is wasteful and counterproductive when the same finding gets re-flagged through commit churn.

## Behavior matrix

| Event | Draft? | Before | After |
|---|---|---|---|
| `opened` | yes | review fires | **no review** |
| `opened` | no | review fires | review fires (unchanged) |
| `synchronize` | yes | review fires | **no review** |
| `synchronize` | no | review fires | review fires (unchanged) |
| `ready_for_review` (draft → ready transition) | n/a | nothing | **review fires once** |
| `reopened` | no | review fires | review fires (unchanged) |

## Files changed

- `.github/workflows/claude-pr-review.yml` — added `ready_for_review` to event types + job-level `if:` skip
- `pr-review/README.md` — new "Draft PRs" section documenting the skip behavior + recommended pattern for `workflow_call` consumers
- `CLAUDE.md` (root) — one-sentence addition to the `pr-review/` action description

## Test plan

After merge, the verification per Issue [#174](https://github.com/glitchwerks/github-actions/issues/174) acceptance criteria:

- [ ] Open a test draft PR with a trivial commit → confirm no review fires
- [ ] Push a second commit to the draft → confirm still no review
- [ ] Click "Ready for review" → confirm review fires once
- [ ] Push a third commit (now non-draft) → confirm review fires

The next time someone opens a draft PR against this repo, the new behavior is automatically observable.

## Out of scope

- Manual override / opt-in to review drafts (e.g., a `review-while-draft` label) — possible follow-up
- Other Claude action workflows (`claude-tag-respond`, `claude-apply-fix`, etc.) — different invocation patterns; not run-on-every-push

Closes #174

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*