### PR TITLE
feat(pr-review): post claude-pr-review/quality-gate status on Critical/MAJOR findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ### Actions
 
-- **`pr-review/`** — Reviews PRs via `anthropics/claude-code-action@v1`. On `synchronize` events, diffs only the new commits (`git diff before..after`) and escalates to a full review if foundational code is touched. Skips review while a PR is in draft; auto-fires once when the PR transitions to ready for review (per #174).
+- **`pr-review/`** — Reviews PRs via `anthropics/claude-code-action@v1`. On `synchronize` events, diffs only the new commits (`git diff before..after`) and escalates to a full review if foundational code is touched. Skips review while a PR is in draft; auto-fires once when the PR transitions to ready for review (per #174). Posts a `claude-pr-review/quality-gate` commit status (per #176) — `failure` when the latest review contains Critical/BLOCKING or High-Priority/MAJOR markers, `success` otherwise; intended to be required by branch protection rulesets.
 - **`tag-claude/`** — Responds to `@claude` mentions. Delegates to `./check-auth` first, then calls `claude-code-action` only if authorized.
 - **`check-auth/`** — Authorization primitive. Outputs `authorized=true/false` based on an explicit `authorized_users` allowlist (takes precedence) or `github.event.comment.author_association` (OWNER/MEMBER/COLLABORATOR). Used by `tag-claude/`.
 - **`apply-fix/`** — Validates a unified diff against protected paths (rejects anything touching `.github/`), applies it with `git apply`, commits, and pushes to the PR branch.

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -78,3 +78,18 @@ The reusable workflow's `jobs.review.if: github.event.pull_request.draft == fals
 (Optional: if you want to skip the `workflow_call` invocation entirely on drafts to avoid the small dispatch overhead, you can add `if: github.event.pull_request.draft == false` to your caller job too. Cosmetic improvement only — the actual `claude-code-action` invocation is already gated.)
 
 **To force a review of a draft:** push a commit while the PR is non-draft, or temporarily mark it ready and back to draft (the `ready_for_review` event will fire).
+
+## Merge gating
+
+The action posts a commit status `claude-pr-review/quality-gate` on the PR's HEAD after each review run:
+
+- **`success`** — the latest review found no Critical/BLOCKING or High-Priority/MAJOR severity markers
+- **`failure`** — at least one such marker was found; merge should be blocked until addressed
+
+To enforce: configure your repo's branch protection ruleset to require `claude-pr-review/quality-gate` as a status check on the protected branch. Once required, GitHub will block merge until the status is `success`.
+
+The bot's sticky comment is the source of truth for what the gate evaluates against — markers are detected via grep on the comment body. The detection patterns are: `🔴 Critical`, `Critical (BLOCKING)`, `🟡 High-Priority`, `MAJOR`, `BLOCKING`.
+
+**Override:** repo admins can bypass via the existing branch-protection bypass mechanism in their ruleset configuration. No code-level override label or comment-trigger is provided — keeps the surface minimal.
+
+**Not the same as `claude-pr-review`:** the action ALSO posts a status with context `claude-pr-review` (no slash) — that's the diff-base checkpoint used internally to scope the next push's review to incremental changes. The `quality-gate` status is the merge-blocking signal; `claude-pr-review` is internal mechanics. Don't require the latter as a branch-protection check.

--- a/pr-review/README.md
+++ b/pr-review/README.md
@@ -88,7 +88,7 @@ The action posts a commit status `claude-pr-review/quality-gate` on the PR's HEA
 
 To enforce: configure your repo's branch protection ruleset to require `claude-pr-review/quality-gate` as a status check on the protected branch. Once required, GitHub will block merge until the status is `success`.
 
-The bot's sticky comment is the source of truth for what the gate evaluates against — markers are detected via grep on the comment body. The detection patterns are: `🔴 Critical`, `Critical (BLOCKING)`, `🟡 High-Priority`, `MAJOR`, `BLOCKING`.
+The bot's sticky comment is the source of truth for what the gate evaluates against — markers are detected via grep on the comment body. The detection patterns are: `🔴 Critical`, `Critical (BLOCKING)`, `🟡 High-Priority`, `**MAJOR**`, `**BLOCKING**`. Note: bare "MAJOR" and "BLOCKING" do NOT trigger the gate — they must appear as markdown bold (`**MAJOR**` / `**BLOCKING**`) to avoid false positives from code snippets, variable names, or prose.
 
 **Override:** repo admins can bypass via the existing branch-protection bypass mechanism in their ruleset configuration. No code-level override label or comment-trigger is provided — keeps the surface minimal.
 

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -217,6 +217,54 @@ runs:
           -f description="Review complete"
         echo "Checkpoint recorded: $AFTER_SHA"
 
+    - name: Quality gate — post claude-pr-review/quality-gate status
+      if: steps.authz.outputs.skip != 'true' && steps.size-check.outputs.skip != 'true' && steps.claude-review.outcome == 'success'
+      shell: bash
+      env:
+        GH_TOKEN: ${{ github.token }}
+        GH_REPOSITORY: ${{ github.repository }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
+        # `github.event.pull_request.head.sha` is the right SHA for the status check.
+        # We post against HEAD because consumers' branch protection rules evaluate
+        # status checks per the HEAD commit of the PR's head branch.
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      run: |
+        set -euo pipefail
+        REPO="$GH_REPOSITORY"
+        PR_NUMBER="$PR_NUMBER"
+
+        # Fetch the most recent comment authored by github-actions[bot]. Claude's
+        # review uses use_sticky_comment: true, which means it edits ONE comment
+        # per PR per workflow run rather than appending; the latest version is
+        # what we grep against.
+        BODY=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+          --jq '[.[] | select(.user.login == "github-actions[bot]")]
+                | sort_by(.updated_at)
+                | last
+                | .body // ""' 2>/dev/null || echo "")
+
+        # Severity-marker grep. Patterns track the bot's existing tier output
+        # format (🔴 emoji + Critical/BLOCKING text, 🟡 + High-Priority, plain MAJOR).
+        # Expanding the pattern is cheap; loosening it later is cheaper than
+        # tightening (false-positive blockers are user-visible immediately).
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -E -c '🔴 Critical|Critical \(BLOCKING\)|🟡 High-Priority|MAJOR|BLOCKING' || true)
+
+        echo "Quality gate scan: $BLOCKER_HITS marker(s) matched in latest sticky comment"
+
+        if [ "$BLOCKER_HITS" -gt "0" ]; then
+          STATE="failure"
+          DESCRIPTION="$BLOCKER_HITS severity marker(s) found in review — see comment"
+        else
+          STATE="success"
+          DESCRIPTION="No Critical or High-Priority findings"
+        fi
+
+        gh api "repos/$REPO/statuses/$HEAD_SHA" \
+          -f state="$STATE" \
+          -f context="claude-pr-review/quality-gate" \
+          -f description="$DESCRIPTION"
+        echo "Posted status: context=claude-pr-review/quality-gate state=$STATE"
+
     - name: Post incomplete-review warning
       if: failure() && steps.authz.outputs.skip != 'true' && steps.size-check.outputs.skip != 'true'
       shell: bash

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -237,23 +237,32 @@ runs:
         # review uses use_sticky_comment: true, which means it edits ONE comment
         # per PR per workflow run rather than appending; the latest version is
         # what we grep against.
-        BODY=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
-          --jq '[.[] | select(.user.login == "github-actions[bot]")]
-                | sort_by(.updated_at)
-                | last
-                | .body // ""' 2>/dev/null || echo "")
+        # sort=updated&direction=desc ensures the most recently edited comment is on
+        # page 1, regardless of total comment count — no pagination needed.
+        BODY=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100&sort=updated&direction=desc" \
+          --jq 'map(select(.user.login == "github-actions[bot]")) | first | .body // ""' \
+          2>/dev/null || echo "")
 
-        # Severity-marker grep. Patterns track the bot's existing tier output
-        # format (🔴 emoji + Critical/BLOCKING text, 🟡 + High-Priority, plain MAJOR).
-        # Expanding the pattern is cheap; loosening it later is cheaper than
-        # tightening (false-positive blockers are user-visible immediately).
-        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -E -c '🔴 Critical|Critical \(BLOCKING\)|🟡 High-Priority|MAJOR|BLOCKING' || true)
+        # If no bot comment exists, the review has not completed — skip the status
+        # post rather than silently posting success (fail-open) or failure (punitive).
+        # Branch protection will see no status and treat it as a missing required
+        # check, which correctly blocks merge until the review actually runs.
+        if [ -z "$BODY" ]; then
+          echo "Quality gate: no github-actions[bot] sticky comment found — skipping status post"
+          exit 0
+        fi
+
+        # Severity-marker grep (post-review-feedback hardening, PR #179 review):
+        # - Emoji-prefixed forms are unique to bot output and specific enough as-is.
+        # - Plain "MAJOR" / "BLOCKING" require markdown bold to avoid matching code
+        #   snippets, prose, or unrelated tokens (SUBMAJOR, MAJOR_VERSION, UNBLOCKING).
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -E -c '🔴 Critical|Critical \(BLOCKING\)|🟡 High-Priority|\*\*MAJOR\*\*|\*\*BLOCKING\*\*' || true)
 
         echo "Quality gate scan: $BLOCKER_HITS marker(s) matched in latest sticky comment"
 
         if [ "$BLOCKER_HITS" -gt "0" ]; then
           STATE="failure"
-          DESCRIPTION="$BLOCKER_HITS severity marker(s) found in review — see comment"
+          DESCRIPTION="$BLOCKER_HITS severity marker(s) matched — see review comment"
         else
           STATE="success"
           DESCRIPTION="No Critical or High-Priority findings"


### PR DESCRIPTION
## Summary

Adds a structural merge gate to the Claude PR review action. After each successful review, the action posts a commit-status `claude-pr-review/quality-gate` to the PR's HEAD SHA:

- **`failure`** — the latest sticky comment contains Critical/BLOCKING or High-Priority/MAJOR markers
- **`success`** — no such markers found

Branch protection rulesets can require this status check; merge is then blocked until the marker is addressed (or a repo admin bypasses).

## Motivation

PR [#171](https://github.com/glitchwerks/github-actions/pull/171) (Phase 2 base image) had the bot flag a critical word-splitting vulnerability across 5+ commits before the maintainer manually noticed and fixed it. The standing rule "always check PR feedback before merge" (memory entry `feedback_check_pr_feedback_before_merge.md`) is the procedural fix; this PR is the structural fix.

## Files changed

- **`pr-review/action.yml`** — appends a new "Quality gate" step after the existing "Record review checkpoint" step. Uses `gh api repos/.../statuses/<sha>` to post the new status on the PR's HEAD.
- **`pr-review/README.md`** — new "Merge gating" section explaining the status, how consumers wire branch protection, and admin override path.
- **`CLAUDE.md`** — one-sentence note appended to the `pr-review/` entry under Architecture → Actions.

## Detection mechanism

Greps the bot's latest sticky comment for: `🔴 Critical | Critical (BLOCKING) | 🟡 High-Priority | MAJOR | BLOCKING`.

**Known fragility:** if Claude reformats its tier output (emoji change, tier rename), the grep stops detecting and the gate silently fails open. Mitigations:

- The markers are part of the action's prompt instruction defaults — unlikely to drift
- Echo log shows what was matched, so silent failures show up in run logs
- Future follow-up can add a structured-output prompt directive (`SEVERITY: <none|critical|major>`) if grep starts misfiring

## Independence from existing `claude-pr-review` status

The existing `claude-pr-review` status (no slash) is the diff-base checkpoint used internally to scope incremental reviews. The new `claude-pr-review/quality-gate` status (with slash) is the merge-blocking signal. **Different contexts; both intentional; do not conflate them.** Branch protection should require ONLY the quality-gate context.

## Override

Repo admins bypass via the existing branch-protection bypass mechanism in their ruleset. No code-level override label or comment-trigger added — keeps the surface minimal.

## Sequencing

- **#129** — restoration of required status checks. After this PR ships, the new context can be added to that restoration set.
- **#137** — bot-based "different eyes" enforcement for runtime overlays. Overlapping but distinct: this PR gates on bot-detected severity; #137 gates on author/path constraints. Both can coexist.
- **`@v3` opt-in** for external consumers — this is technically a breaking change because consumers' branch protection won't know about the new status until they require it. Documented in the README's "Merge gating" section; not a hard cut on this PR.

## Test plan

- [ ] PR opens cleanly (no merge conflicts)
- [ ] Lint check passes (composite-action YAML follows existing style)
- [ ] First review on this PR posts the new status as `success` (assuming the bot's review of this PR doesn't itself find Critical/MAJOR issues — meta-check)
- [ ] Manual: after merge, verify a future PR with a deliberate Critical finding gets `failure` status

Closes #176

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*