### PR TITLE
docs: sync CLAUDE.md "CI Runtime" section with post-Phase-2 reality

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,13 +65,12 @@ The `runtime/` tree is the authoritative source for the containerized CI Claude 
 - `runtime/ci-manifest.yaml` — single source of truth for what gets baked into each image
 - `runtime/ci-manifest.schema.json` — structural rules (validated by `ajv` in STAGE 1)
 - `runtime/scripts/validate-manifest.sh` — semantic rules (path existence, plugin collisions, override collisions)
-- `runtime/scripts/ghcr-immutability-preflight.sh` — verifies all four GHCR packages have "Prevent tag overwrites" enabled
 
 The manifest's `sources.private.ref` MUST match `^ci-v\d+\.\d+\.\d+$` and resolve to a real tag in `glitchwerks/claude-configs`. Bumping that pin requires a manual review of the `git diff` between the old and new tag. The marketplace SHA pin (`sources.marketplace.ref`) follows the same manual-on-observed-value cadence (spec §13 Q5).
 
 The build workflow `.github/workflows/runtime-build.yml` runs STAGE 1 on `pull_request` events touching `runtime/**` (validation gate before merge) and on `push` to `main` (post-merge re-verification). Phase 2 (image build) appends STAGE 2 to the same workflow.
 
-**Phase 2 status (post-merge of this PR):** the base image at `ghcr.io/glitchwerks/claude-runtime-base@sha256:<digest>` is the foundation for all overlays in Phase 3. It is built from `node:20-slim` (digest-pinned) plus the materialized `shared.*` tree from `runtime/ci-manifest.yaml`. The smoke test asserts non-zero counts for agents/skills/plugins enumerated by Claude Code CLI as a non-root UID. Phase 0 #138 C3 closure: the `claude-runtime-base` package's "Prevent tag overwrites" toggle is now ON; the other three packages close in Phase 3.
+**Phase 2 status (post-merge of this PR):** the base image at `ghcr.io/glitchwerks/claude-runtime-base@sha256:<digest>` is the foundation for all overlays in Phase 3. It is built from `node:20-slim` (digest-pinned) plus the materialized `shared.*` tree from `runtime/ci-manifest.yaml`. The smoke test asserts non-zero counts for agents/skills/plugins enumerated by Claude Code CLI as a non-root UID. **Reproducibility model:** GHCR does not support tag immutability (per Issue [#173](https://github.com/glitchwerks/github-actions/issues/173)); reproducibility is enforced via digest pins (`@sha256:<digest>`) in reusable workflow files — content-addressed and inherently immutable. The `:<pubsha>` tag alias is cosmetic. Phase 0 [#138](https://github.com/glitchwerks/github-actions/issues/138) was closed; criterion C3 was superseded by the digest-pin pivot rather than satisfied.
 
 ## Versioning
 


### PR DESCRIPTION
## Summary

Doc-only single-file PR removing two stale claims from `CLAUDE.md` "CI Runtime (Phase 1+)" section that were left over after Phase 2's GHCR pivot.

## What was wrong

**Line 68** — pointed at a deleted script:

```
- `runtime/scripts/ghcr-immutability-preflight.sh` — verifies all four GHCR packages have "Prevent tag overwrites" enabled
```

The script was deleted in PR [#171](https://github.com/glitchwerks/github-actions/pull/171) (commit `0ccc198`) when Phase 2 discovered GHCR doesn't support tag immutability — see Issue [#173](https://github.com/glitchwerks/github-actions/issues/173). Bullet removed.

**Line 74 (in the "Phase 2 status" paragraph)** — claimed a non-existent toggle:

> "Phase 0 #138 C3 closure: the `claude-runtime-base` package's 'Prevent tag overwrites' toggle is now ON; the other three packages close in Phase 3."

That toggle is fictional (community feature request, never implemented). Replaced with an accurate "Reproducibility model" sentence stating that reproducibility is enforced via digest pins, with cross-references to #173 and #138.

## Files changed

- `CLAUDE.md` — 2 lines deleted (the stale bullet and the stale closure claim), 1 line added (the new reproducibility-model sentence)

## What this PR does NOT touch (intentionally)

- `docs/superpowers/plans/2026-04-22-ci-claude-runtime.md` — master plan with multiple historical references to the deleted preflight; out of scope for this issue. If the bot review flags it, it'll get its own follow-up issue (same pattern we used to spawn #178 from #177).
- `docs/superpowers/plans/phase-1-scaffold.md` — already amended in PR [#177](https://github.com/glitchwerks/github-actions/pull/177) (Issue #172).
- `docs/superpowers/specs/2026-04-21-ci-claude-runtime-design.md` — §6.3.1 already amended in PR #171.
- `README.md` — scan confirmed no stale references.

## Test plan

- [ ] PR opens cleanly (no merge conflicts)
- [ ] `actionlint` passes (no workflow changes)
- [ ] New `claude-pr-review/quality-gate` status (just shipped via PR #179) posts as `success` — meta-check that the gate works on its first real-world PR
- [ ] Bot review confirms the cleanup is accurate and complete in scope

Closes #178

🤖 *Generated by Claude Code on behalf of @cbeaulieu-gt*