### PR TITLE
Phase 5: digest-pin reusable workflows + tag-respond router/dispatch

### DIFF
--- a/.github/workflows/claude-apply-fix.yml
+++ b/.github/workflows/claude-apply-fix.yml
@@ -1,0 +1,53 @@
+name: Claude Apply Fix
+
+# Phase 5 (#188): reusable-workflow form of the fix-apply path.
+# Distinct from `apply-fix.yml` (workflow_dispatch-only manual entrypoint —
+# stays until Phase 7). External consumers reference this file via
+# `uses: glitchwerks/github-actions/.github/workflows/claude-apply-fix.yml@v2`.
+
+on:
+  workflow_call:
+    secrets:
+      app_id:
+        required: true
+      app_private_key:
+        required: true
+    inputs:
+      pr_number:
+        description: 'PR number to apply the fix to'
+        type: string
+        required: true
+      fix_diff:
+        description: 'Unified diff to apply'
+        type: string
+        required: true
+      fix_description:
+        description: 'One-line description of the fix (used as the commit message body)'
+        type: string
+        required: true
+
+# Workflow-level permissions per CLAUDE.md "Permissions must be declared at the
+# workflow level" — GitHub ignores job-level permissions when calling reusable
+# workflows from external consumers.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  apply:
+    runs-on: ubuntu-latest
+    # Phase 5: pin the fix overlay image by SHA256 digest. The fix overlay
+    # carries the agent set required for code-write tasks (per spec §7.5).
+    # Digest source: STAGE 3 build run 25261308990 (Phase 3 merge, c8d9b7e).
+    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:da2b6e52ad20159252cb6f24147d4ece221182dbb0b21df9fb32966126e24a20
+    concurrency:
+      group: claude-apply-fix-${{ github.repository }}-${{ inputs.pr_number }}
+      cancel-in-progress: false
+    steps:
+      - uses: glitchwerks/github-actions/apply-fix@v2
+        with:
+          pr_number: ${{ inputs.pr_number }}
+          fix_diff: ${{ inputs.fix_diff }}
+          fix_description: ${{ inputs.fix_description }}
+          app_id: ${{ secrets.app_id }}
+          app_private_key: ${{ secrets.app_private_key }}

--- a/.github/workflows/claude-ci-failure.yml
+++ b/.github/workflows/claude-ci-failure.yml
@@ -1,0 +1,188 @@
+name: Claude CI Failure
+
+# Phase 5 (#188): reusable-workflow form of CI-failure diagnosis, pinning the
+# fix overlay image. Distinct from `ci-failure.yaml` (this repo's `workflow_run`
+# self-hook — kept until Phase 7). External consumers wire this up in their own
+# repo by adding a `notify-claude` job (with `needs: [<their CI job>]` and
+# `if: failure()`) that calls this workflow with `pr_number` and `run_id`.
+#
+# Per spec §7.5, the fix overlay handles both diagnosis and (optionally)
+# auto-apply on this path; behavior is governed by the `auto_apply` input.
+
+on:
+  workflow_call:
+    secrets:
+      claude_code_oauth_token:
+        required: true
+      app_id:
+        required: true
+      app_private_key:
+        required: true
+    inputs:
+      pr_number:
+        description: 'Pull request number — pass github.event.pull_request.number from the caller'
+        type: string
+        required: true
+      run_id:
+        description: 'Failed CI run ID for log fetch — pass github.run_id from the caller'
+        type: string
+        required: true
+      model:
+        description: 'Claude model to use'
+        type: string
+        required: false
+        default: 'claude-sonnet-4-5'
+      max_turns:
+        description: 'Maximum number of Claude turns'
+        type: string
+        required: false
+        default: '30'
+      auto_apply:
+        description: 'If true, a high-confidence patch will be committed and pushed automatically'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    # Phase 5: pin the fix overlay image by SHA256 digest. The diagnose path
+    # uses the fix overlay (per §7.5) rather than a dedicated diagnose overlay
+    # — the same agent set handles read-only and apply paths, behavior is
+    # gated by the `auto_apply` input passed to the prompt.
+    # Digest source: STAGE 3 build run 25261308990 (Phase 3 merge, c8d9b7e).
+    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:da2b6e52ad20159252cb6f24147d4ece221182dbb0b21df9fb32966126e24a20
+    concurrency:
+      group: claude-ci-failure-${{ github.repository }}-${{ inputs.pr_number }}
+      cancel-in-progress: true
+    steps:
+      - name: Generate App token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
+      - name: Resolve write token
+        id: token
+        shell: bash
+        # shellcheck disable=SC2016
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -n "$APP_TOKEN" ]; then
+            echo "::debug::Using GitHub App token"
+            echo "value=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::No authentication token provided. Set app_id + app_private_key secrets."
+            exit 1
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          token: ${{ steps.token.outputs.value }}
+          fetch-depth: 0
+
+      - name: Configure git identity
+        shell: bash
+        run: |
+          git config user.name "Claude Auto-Fix"
+          git config user.email "claude-autofix@users.noreply.github.com"
+
+      - name: Fetch failed job logs
+        id: logs
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.value }}
+          GH_REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ inputs.run_id }}
+        run: |
+          LOG_URL="https://github.com/${GH_REPOSITORY}/actions/runs/${RUN_ID}"
+          echo "log_url=$LOG_URL" >> "$GITHUB_OUTPUT"
+
+          # See ci-failure.yaml for the SIGPIPE rationale on the head -c split.
+          gh run view "$RUN_ID" --log-failed > /tmp/ci_full_logs.txt 2>/tmp/log_err.txt
+          exit_code=$?
+          if [ $exit_code -ne 0 ] && [ -s /tmp/log_err.txt ]; then
+            echo "::error::Failed to download CI logs: $(cat /tmp/log_err.txt)"
+            exit 1
+          fi
+          head -c 16000 /tmp/ci_full_logs.txt > /tmp/ci_logs.txt || true
+
+      - name: Fetch PR diff
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.value }}
+          GH_REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          gh api "repos/${GH_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+            --jq '[.[] | {filename: .filename, patch: .patch}]' \
+            | head -c 8000 > /tmp/pr_diff.json
+
+      - name: Diagnose failure and optionally apply fix
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
+          github_token: ${{ steps.token.outputs.value }}
+          use_sticky_comment: true
+          track_progress: true
+          claude_args: --max-turns ${{ inputs.max_turns }} --model ${{ inputs.model }}
+          prompt: |
+            A GitHub Actions CI run has failed on pull request #${{ inputs.pr_number }} in repository ${{ github.repository }}.
+
+            Your job is to diagnose the failure and, if you are confident you have a minimal fix, apply it directly.
+
+            ## Step 1 — Read the evidence
+
+            Read the following files that were written by prior workflow steps:
+            - `/tmp/ci_logs.txt` — the raw log output from all failed CI steps (up to 16 000 chars)
+            - `/tmp/pr_diff.json` — the files changed by the PR, with their diffs (JSON array)
+
+            Also read `CLAUDE.md` if it exists in the repository root — it gives project-specific context.
+
+            ## Step 2 — Post a structured diagnosis comment
+
+            Post a comment on PR #${{ inputs.pr_number }} using the GitHub CLI (`gh pr comment ${{ inputs.pr_number }} --body "..."`).
+
+            The comment must follow this exact structure (use the markdown headings as shown):
+
+            ```
+            ## Claude CI Diagnosis
+
+            **Summary:** <one sentence describing what failed>
+
+            **Root cause:** <2–3 sentences explaining why it failed>
+
+            **Suggested fix:** <one sentence describing the minimal change needed>
+
+            ```diff
+            <unified diff of the fix, or omit this block entirely if no code change is needed>
+            ```
+
+            **Confidence:** <high | medium | low> | [View full logs](${{ steps.logs.outputs.log_url }})
+
+            ---
+            _This diagnosis was generated automatically by Claude. Review before applying any suggested fix._
+            ```
+
+            ## Step 3 — Apply the fix (conditional)
+
+            Auto-apply is **${{ inputs.auto_apply && 'enabled' || 'disabled' }}** for this run.
+
+            If auto-apply is **enabled** AND your confidence is **high** AND you produced a non-empty fix diff:
+
+            1. Confirm the fix diff does not touch any path under `.github/`. If it does, skip the apply and note this in the comment.
+            2. Write the unified diff to `/tmp/autofix.patch`.
+            3. Apply it: `git apply --index /tmp/autofix.patch`
+            4. Commit with a message describing the fix.
+            5. Push to the PR branch: first run `gh api repos/${{ github.repository }}/pulls/${{ inputs.pr_number }} --jq '.head.ref'` to get the branch name, then `git push origin HEAD:<branch>`.
+            6. Append a brief note to the PR comment confirming the fix was applied and the commit SHA.
+
+            If auto-apply is **disabled**, or your confidence is **medium** or **low**, or there is no fix diff, stop after posting the comment. Do not modify any files.

--- a/.github/workflows/claude-lint-failure.yml
+++ b/.github/workflows/claude-lint-failure.yml
@@ -1,0 +1,74 @@
+name: Claude Lint Failure
+
+# Phase 5 (#188): reusable-workflow form of the lint-diagnosis + auto-fix path,
+# pinning the fix overlay image. Per spec §7.5, the SAME image handles BOTH the
+# read-only diagnosis path and the auto-apply path; behavior switches on the
+# `auto_apply` input which is forwarded to the `lint-failure` composite action.
+#
+# Distinct from `claude-lint-fix.yml` (the legacy two-job form using
+# `lint-diagnose/` + `lint-apply/` — kept for backwards compatibility until
+# Phase 7 cutover). External consumers should migrate the `uses:` line to
+# `glitchwerks/github-actions/.github/workflows/claude-lint-failure.yml@v2`.
+
+on:
+  workflow_call:
+    secrets:
+      claude_code_oauth_token:
+        required: true
+      app_id:
+        required: true
+      app_private_key:
+        required: true
+    inputs:
+      pr_number:
+        description: 'Pull request number — pass github.event.pull_request.number from the caller'
+        type: string
+        required: true
+      run_id:
+        description: 'Workflow run ID for log fetch — pass github.run_id from the caller'
+        type: string
+        required: true
+      model:
+        description: 'Claude model to use'
+        type: string
+        required: false
+        default: 'claude-sonnet-4-5'
+      max_turns:
+        description: 'Maximum number of Claude turns'
+        type: string
+        required: false
+        default: '20'
+      auto_apply:
+        description: 'If true, a high-confidence patch will be committed and pushed automatically'
+        type: boolean
+        required: false
+        default: false
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-latest
+    # Phase 5: pin the fix overlay image by SHA256 digest. Per spec §7.5,
+    # the fix overlay handles both read-only diagnosis (auto_apply: false)
+    # and the auto-apply path (auto_apply: true) — the composite action's
+    # behavior switches on the input, the image does not.
+    # Digest source: STAGE 3 build run 25261308990 (Phase 3 merge, c8d9b7e).
+    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:da2b6e52ad20159252cb6f24147d4ece221182dbb0b21df9fb32966126e24a20
+    concurrency:
+      group: claude-lint-failure-${{ github.repository }}-${{ inputs.pr_number }}
+      cancel-in-progress: true
+    steps:
+      - uses: glitchwerks/github-actions/lint-failure@v2
+        with:
+          claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
+          app_id: ${{ secrets.app_id }}
+          app_private_key: ${{ secrets.app_private_key }}
+          pr_number: ${{ inputs.pr_number }}
+          run_id: ${{ inputs.run_id }}
+          model: ${{ inputs.model }}
+          max_turns: ${{ inputs.max_turns }}
+          auto_apply: ${{ inputs.auto_apply }}

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -39,6 +39,13 @@ jobs:
     # iterative draft work (cf. PR #171 which accumulated 14 review runs as a draft).
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
+    # Phase 5 (#188): pin the review overlay image by SHA256 digest.
+    # The composite action's bash steps and the embedded `claude-code-action@v1`
+    # invocation all run inside this container. The image bakes in Claude CLI
+    # at $PATH_TO_CLAUDE_CODE_EXECUTABLE plus the review-specific agent set
+    # (different-eyes guarantee per spec §3.1, §10.2).
+    # Digest source: STAGE 3 build run 25261308990 (Phase 3 merge, c8d9b7e).
+    container: ghcr.io/glitchwerks/claude-runtime-review@sha256:776980ed9009fe17dfdb782960978bd573842dc867728bd4e63d734871cdeef1
     concurrency:
       group: claude-pr-review-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/claude-tag-respond.yml
+++ b/.github/workflows/claude-tag-respond.yml
@@ -1,5 +1,20 @@
 name: Claude Tag Respond
 
+# Phase 5 (#188): replaces the v2 tag-claude-backed implementation with a
+# router/dispatch flow per spec §8.2. The `route` job parses the comment via
+# `claude-command-router/` (Phase 4, #142), looks up the matching overlay
+# image digest, and emits the full image URL as an output. The `dispatch`
+# job pins `container:` to that URL and runs `claude-code-action@v1` inside
+# the verb-specific overlay (review / fix / explain).
+#
+# Spec §8.2 example used `./claude-command-router` (relative); we use the
+# absolute `glitchwerks/github-actions/claude-command-router@v2` ref because
+# external consumers fetching this workflow file run it against THEIR repo's
+# checkout, where `./claude-command-router` would not resolve. This matches
+# the CLAUDE.md "absolute refs, not relative paths" convention for any
+# action exposed to external consumers — and the router is reachable via
+# this caller workflow even though consumers never name it directly.
+
 on:
   workflow_call:
     secrets:
@@ -15,13 +30,8 @@ on:
         type: string
         required: false
         default: '@claude'
-      require_association:
-        description: 'Only allow OWNER, MEMBER, and COLLABORATOR to trigger Claude'
-        type: boolean
-        required: false
-        default: true
       authorized_users:
-        description: 'Comma-separated list of GitHub usernames authorized to trigger Claude. When set, overrides require_association.'
+        description: 'Comma-separated list of GitHub usernames authorized to trigger Claude. When set, overrides author_association check.'
         type: string
         required: false
         default: ''
@@ -40,28 +50,213 @@ on:
 # (issue_comment, pull_request_review_comment, etc.) — this reusable
 # workflow only handles the job logic.
 
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 jobs:
-  respond:
+  route:
+    # Cheap pre-filter: only spin up the route job when @claude appears in the
+    # triggering comment body. Saves a runner minute on every unrelated comment.
+    if: contains(github.event.comment.body, '@claude')
     runs-on: ubuntu-latest
-    # Per-user concurrency: if a second comment arrives from the same user
-    # while a run is in progress, the in-progress run is cancelled and the
-    # new one takes over. This prevents queued pile-ups from rapid @claude
-    # mentions.
     concurrency:
-      group: claude-tag-${{ github.repository }}-${{ github.event.comment.user.login }}
+      group: claude-tag-respond-route-${{ github.repository }}-${{ github.event.comment.user.login }}
       cancel-in-progress: true
-    permissions:
-      contents: write
-      issues: write
-      pull-requests: write
+    outputs:
+      overlay: ${{ steps.r.outputs.overlay }}
+      status:  ${{ steps.r.outputs.status }}
+      mode:    ${{ steps.r.outputs.mode }}
+      image:   ${{ steps.image.outputs.image }}
     steps:
-      - uses: glitchwerks/github-actions/tag-claude@v2
+      - uses: actions/checkout@v5
+
+      - id: r
+        uses: glitchwerks/github-actions/claude-command-router@v2
+        with:
+          comment_body: ${{ github.event.comment.body }}
+          authorized_users: ${{ inputs.authorized_users }}
+
+      # Phase 5: map the resolved overlay name to its digest-pinned image URL.
+      # Encapsulating the lookup here keeps the router pure (no awareness of
+      # image names or digests) and lets `dispatch` consume a single
+      # already-resolved string in `container:`. Updating the digest pins on
+      # promotion (Phase 6, #143) only touches this lookup table.
+      # Digest source: STAGE 3 build run 25261308990 (Phase 3 merge, c8d9b7e).
+      - id: image
+        if: steps.r.outputs.status == 'ok'
+        shell: bash
+        env:
+          OVERLAY: ${{ steps.r.outputs.overlay }}
+        run: |
+          set -euo pipefail
+          case "$OVERLAY" in
+            review)
+              IMG="ghcr.io/glitchwerks/claude-runtime-review@sha256:776980ed9009fe17dfdb782960978bd573842dc867728bd4e63d734871cdeef1"
+              ;;
+            fix)
+              IMG="ghcr.io/glitchwerks/claude-runtime-fix@sha256:da2b6e52ad20159252cb6f24147d4ece221182dbb0b21df9fb32966126e24a20"
+              ;;
+            explain)
+              IMG="ghcr.io/glitchwerks/claude-runtime-explain@sha256:23dd59f2651ebc9aba93b5c143d5b78d256c8abe1ebf970ad9c218f6aa06ff77"
+              ;;
+            *)
+              echo "::error::router emitted status=ok but overlay=$OVERLAY is not in the known set (review|fix|explain). Aborting."
+              exit 1
+              ;;
+          esac
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+
+      # Reply to the user when the router rejects the comment. Keeps the
+      # error surface inline with the routing decision rather than a
+      # downstream concern. See spec §8.3.
+      - name: Post router rejection comment
+        if: steps.r.outputs.status == 'unknown_verb' || steps.r.outputs.status == 'malformed' || steps.r.outputs.status == 'unauthorized'
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          STATUS: ${{ steps.r.outputs.status }}
+        run: |
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "::warning::router status=$STATUS but no issue.number in event context — skipping reply"
+            exit 0
+          fi
+          case "$STATUS" in
+            unknown_verb|malformed)
+              MSG="I don't recognize that command. Supported: \`review\`, \`fix\` (or \`fix --read-only\`), \`explain\`."
+              ;;
+            unauthorized)
+              MSG="Automated @claude responses are restricted to repository members. A maintainer can trigger by commenting with the same phrase."
+              ;;
+          esac
+          gh issue comment "$ISSUE_NUMBER" --body "$MSG"
+
+  dispatch:
+    needs: route
+    if: needs.route.outputs.status == 'ok'
+    runs-on: ubuntu-latest
+    # Single dispatch job, container resolved from `route` outputs. §13 Q2
+    # verification (PR body): `${{ needs.* }}` is supported in
+    # `jobs.<id>.container.image` per the GHA context-availability table, so
+    # the discrete-jobs fallback was not needed.
+    container: ${{ needs.route.outputs.image }}
+    concurrency:
+      group: claude-tag-respond-dispatch-${{ github.repository }}-${{ github.event.comment.user.login }}
+      cancel-in-progress: true
+    # Reflect App-credential presence into a job-level env var so step-level
+    # `if:` expressions can gate on it. Step-level `if:` cannot reference
+    # `secrets` directly (per GHA context-availability table), but `env:` at
+    # job scope is allowed to read `secrets`, which makes this proxy safe.
+    env:
+      HAS_APP_CREDS: ${{ secrets.app_id != '' && secrets.app_private_key != '' && 'true' || 'false' }}
+    steps:
+      - name: Generate App token
+        id: app-token
+        if: env.HAS_APP_CREDS == 'true'
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.app_id }}
+          private-key: ${{ secrets.app_private_key }}
+
+      - name: Resolve write token
+        id: token
+        shell: bash
+        # shellcheck disable=SC2016
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          if [ -n "$APP_TOKEN" ]; then
+            echo "::debug::Using GitHub App token"
+            echo "value=$APP_TOKEN" >> "$GITHUB_OUTPUT"
+          else
+            # Fall back to GITHUB_TOKEN if the App credentials are not provisioned.
+            # Note: GitHub suppresses `synchronize` events for pushes authenticated
+            # with GITHUB_TOKEN, so commits pushed via this fallback won't re-trigger
+            # downstream workflows. App token is preferred (see CLAUDE.md "Token selection").
+            echo "::debug::Using GITHUB_TOKEN fallback"
+            echo "value=${{ github.token }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/checkout@v5
+        with:
+          token: ${{ steps.token.outputs.value }}
+
+      - name: Build claude args
+        id: args
+        shell: bash
+        env:
+          MODEL: ${{ inputs.model }}
+          MAX_TURNS: ${{ inputs.max_turns }}
+        run: |
+          ARGS="--model $MODEL"
+          if [ -n "$MAX_TURNS" ]; then
+            ARGS="$ARGS --max-turns $MAX_TURNS"
+          fi
+          echo "claude_args=$ARGS" >> "$GITHUB_OUTPUT"
+
+      - name: Record run start time
+        shell: bash
+        run: echo "RUN_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
+
+      - uses: anthropics/claude-code-action@v1
+        env:
+          # Surfaces the router's mode decision to the verb-specific overlay
+          # persona. The fix overlay's CLAUDE.md may inspect READ_ONLY_MODE
+          # to decline commits when set to 'true' (per spec §8.1.1 and §7.5).
+          # Other overlays ignore it. This keeps mode out of `claude_args`
+          # (which is reserved for actual CLI flags) and out of the prompt
+          # text (which would be parser-fragile).
+          READ_ONLY_MODE: ${{ needs.route.outputs.mode == 'read-only' && 'true' || 'false' }}
+          OVERLAY: ${{ needs.route.outputs.overlay }}
         with:
           claude_code_oauth_token: ${{ secrets.claude_code_oauth_token }}
-          app_id: ${{ secrets.app_id }}
-          app_private_key: ${{ secrets.app_private_key }}
+          github_token: ${{ steps.token.outputs.value }}
           trigger_phrase: ${{ inputs.trigger_phrase }}
-          require_association: ${{ inputs.require_association }}
-          authorized_users: ${{ inputs.authorized_users }}
-          model: ${{ inputs.model }}
-          max_turns: ${{ inputs.max_turns }}
+          claude_args: ${{ steps.args.outputs.claude_args }}
+
+      - name: Post incomplete-run warning
+        if: failure()
+        shell: bash
+        # shellcheck disable=SC2016
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.value }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          MAX_TURNS: ${{ inputs.max_turns }}
+          RUN_START_TIME: ${{ env.RUN_START_TIME }}
+        run: |
+          if [ -z "$ISSUE_NUMBER" ]; then
+            echo "No issue number found in event context, skipping incomplete-run warning"
+            exit 0
+          fi
+
+          # Skip the warning if Claude already posted a comment during this run.
+          # Filter by author (github-actions[bot]) and timestamp to avoid false positives
+          # from prior runs on the same issue/PR.
+          COMMENT_COUNT=$(gh issue view "$ISSUE_NUMBER" --json comments \
+            | jq --arg since "$RUN_START_TIME" \
+            '[.comments[] | select(.author.login == "github-actions[bot]") | select(.createdAt > $since)] | length' \
+            2>/dev/null || echo "0")
+
+          if [ "$COMMENT_COUNT" -gt "0" ]; then
+            echo "Claude posted a comment during this run before hitting the turn limit — skipping incomplete-run warning"
+            exit 0
+          fi
+
+          if [ -n "$MAX_TURNS" ]; then
+            TURNS_MSG="The run was cut off at $MAX_TURNS turns."
+          else
+            TURNS_MSG="The run was cut off when Claude hit its turn limit."
+          fi
+
+          gh issue comment "$ISSUE_NUMBER" --body "$(cat <<EOF
+          ⚠️ **@claude run incomplete**
+
+          $TURNS_MSG
+
+          **Options:**
+          - Re-trigger with \`@claude\` and a more focused request
+          - Pass a higher \`max_turns\` value in the caller workflow
+          EOF
+          )"

--- a/.github/workflows/claude-tag-respond.yml
+++ b/.github/workflows/claude-tag-respond.yml
@@ -68,6 +68,8 @@ jobs:
       overlay: ${{ steps.r.outputs.overlay }}
       status:  ${{ steps.r.outputs.status }}
       mode:    ${{ steps.r.outputs.mode }}
+      # Full ghcr.io URL with @sha256:<digest> suffix; consumed by `dispatch` as `container:`.
+      # Empty string when status != 'ok' (the lookup step is gated on status='ok').
       image:   ${{ steps.image.outputs.image }}
     steps:
       - uses: actions/checkout@v5
@@ -102,7 +104,7 @@ jobs:
               IMG="ghcr.io/glitchwerks/claude-runtime-explain@sha256:23dd59f2651ebc9aba93b5c143d5b78d256c8abe1ebf970ad9c218f6aa06ff77"
               ;;
             *)
-              echo "::error::router emitted status=ok but overlay=$OVERLAY is not in the known set (review|fix|explain). Aborting."
+              echo "::error::router emitted status=ok but overlay=$OVERLAY is not in the known set (review|fix|explain). Add the new overlay to the case statement in the 'image' step of the route job (.github/workflows/claude-tag-respond.yml)."
               exit 1
               ;;
           esac
@@ -190,11 +192,11 @@ jobs:
           MODEL: ${{ inputs.model }}
           MAX_TURNS: ${{ inputs.max_turns }}
         run: |
-          ARGS="--model $MODEL"
+          ARGS="--model ${MODEL}"
           if [ -n "$MAX_TURNS" ]; then
-            ARGS="$ARGS --max-turns $MAX_TURNS"
+            ARGS="${ARGS} --max-turns ${MAX_TURNS}"
           fi
-          echo "claude_args=$ARGS" >> "$GITHUB_OUTPUT"
+          echo "claude_args=${ARGS}" >> "$GITHUB_OUTPUT"
 
       - name: Record run start time
         shell: bash

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,9 +43,16 @@ The reusable workflows are thin wrappers that delegate to the composite actions 
 
 ### CI automation workflows
 
-- **`ci-failure.yaml`** — Triggered by `workflow_run` on CI failure. Fetches plain-text logs via `gh run view --log-failed`, writes them to `/tmp/ci_logs.txt`, calls `claude-code-action` to diagnose and optionally auto-apply a fix.
-- **`apply-fix.yml`** — `workflow_dispatch` wrapper around `./apply-fix` for manual invocation.
-- **`claude-lint-fix.yml`** — `workflow_call`-only wrapper around `./lint-failure`. Consumers add a `notify-claude` job (with `needs: [lint]` and `if: failure()`) to their lint workflow.
+The `claude-*.yml` reusable workflows (everything except `ci-failure.yaml` and `apply-fix.yml`) are container-pinned to overlay images at SHA256 digest as of Phase 5 (#188). The job's `container:` field selects the runtime image, which bakes in Claude CLI plus a verb-specific agent set; the composite action's bash steps and embedded `claude-code-action@v1` invocation all run inside that container.
+
+- **`ci-failure.yaml`** — Triggered by `workflow_run` on CI failure. Fetches plain-text logs via `gh run view --log-failed`, writes them to `/tmp/ci_logs.txt`, calls `claude-code-action` to diagnose and optionally auto-apply a fix. **Not container-pinned** — kept until Phase 7 cutover; consumers should migrate to `claude-ci-failure.yml`.
+- **`apply-fix.yml`** — `workflow_dispatch` wrapper around `./apply-fix` for manual invocation. **Not container-pinned** — kept for the manual-trigger path.
+- **`claude-pr-review.yml`** — Container-pinned to `claude-runtime-review`. Both `pull_request_target` (this repo's dogfood) and `workflow_call` (external consumers).
+- **`claude-apply-fix.yml`** — `workflow_call`-only wrapper around `./apply-fix`, container-pinned to `claude-runtime-fix`. Phase 5 (#188) — consumer-facing reusable form of the manual-fix path.
+- **`claude-lint-failure.yml`** — `workflow_call`-only wrapper around `./lint-failure`, container-pinned to `claude-runtime-fix`. Per spec §7.5, both the read-only diagnosis path and the auto-apply path use the same overlay; behavior is gated by the `auto_apply` input.
+- **`claude-lint-fix.yml`** — Legacy two-job (`./lint-diagnose` + `./lint-apply`) form, NOT container-pinned. Kept until Phase 7 cutover; consumers should migrate to `claude-lint-failure.yml`.
+- **`claude-ci-failure.yml`** — `workflow_call`-only CI-failure diagnosis form, container-pinned to `claude-runtime-fix`. Phase 5 (#188) — consumer-facing reusable form alongside the existing `ci-failure.yaml`.
+- **`claude-tag-respond.yml`** — Two-job (`route` → `dispatch`) flow. The `route` job invokes `glitchwerks/github-actions/claude-command-router@v2` (Phase 4), maps the resolved overlay to its digest-pinned image URL, and emits the URL as a job output. The `dispatch` job pins `container:` to that URL and runs `claude-code-action@v1` inside the verb-specific overlay (review / fix / explain). The `READ_ONLY_MODE` env var is forwarded into `dispatch` so the fix overlay's persona can decline commits when the router emitted `mode=read-only`. Phase 5 (#188) — successor to the v2 `tag-claude/`-backed implementation.
 
 ## Key conventions
 

--- a/README.md
+++ b/README.md
@@ -212,6 +212,14 @@ When a new major version is released (e.g., v3), a new floating tag will be crea
 
 The overlay layer also introduces `overlays.<verb>.subtract_from_shared.plugins`, which removes a base-inherited plugin from a specific overlay at build time (review subtracts `skill-creator` for §10.2 compliance). See spec §4.2 / §5.1 amendments for the relationship to `merge_policy.overrides` (no interaction). Implementation plan: `docs/superpowers/plans/phase-3-overlays.md`.
 
+### CI runtime — reusable workflow wiring (Phase 5)
+
+The Phase 3 overlay images are wired into the consumer-facing reusable workflows via `container: ghcr.io/.../claude-runtime-<verb>@sha256:<digest>` at the job level. Every step in the job — including the embedded `claude-code-action@v1` invocation — runs inside the verb-specific overlay image, which bakes Claude CLI at `$PATH_TO_CLAUDE_CODE_EXECUTABLE` plus the verb's agent set. The interface to consumers is unchanged: a single `uses:` line plus the OAuth secret. See `docs/superpowers/specs/2026-04-21-ci-claude-runtime-design.md` §7.5 for workflow → overlay assignments and `docs/superpowers/plans/2026-04-22-ci-claude-runtime.md` "Phase 5" for the implementation plan.
+
+For the `claude-tag-respond.yml` flow, the `route` job invokes `claude-command-router/` (Phase 4) to parse the verb and emits a digest-pinned image URL that the `dispatch` job consumes via `container: ${{ needs.route.outputs.image }}`. Consumers don't see the routing — they just `uses:` the workflow as before.
+
+**Migration note (Phase 5 → Phase 7):** `claude-lint-fix.yml`, `apply-fix.yml`, and `ci-failure.yaml` are kept until Phase 7 cutover. New consumers should reference `claude-lint-failure.yml`, `claude-apply-fix.yml`, and `claude-ci-failure.yml` respectively — all three are container-pinned to the fix overlay.
+
 ---
 
 ## CI Failure Diagnosis

--- a/docs/superpowers/specs/2026-04-21-ci-claude-runtime-design.md
+++ b/docs/superpowers/specs/2026-04-21-ci-claude-runtime-design.md
@@ -566,20 +566,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - id: r
-        uses: ./claude-command-router
+        uses: glitchwerks/github-actions/claude-command-router@v2
         with:
           comment_body: ${{ github.event.comment.body }}
           authorized_users: ${{ inputs.authorized_users }}
+      - id: image
+        if: steps.r.outputs.status == 'ok'
+        run: |
+          case "${{ steps.r.outputs.overlay }}" in
+            review)  IMG="ghcr.io/glitchwerks/claude-runtime-review@sha256:<digest>" ;;
+            fix)     IMG="ghcr.io/glitchwerks/claude-runtime-fix@sha256:<digest>" ;;
+            explain) IMG="ghcr.io/glitchwerks/claude-runtime-explain@sha256:<digest>" ;;
+          esac
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
 
   dispatch:
     needs: route
     if: needs.route.outputs.status == 'ok'
     runs-on: ubuntu-latest
-    container: ghcr.io/glitchwerks/claude-runtime-${{ needs.route.outputs.overlay }}@sha256:<digest>
+    container: ${{ needs.route.outputs.image }}
     # ... rest of dispatch
 ```
 
-**Relative path note:** The router is invoked as `./claude-command-router` (relative) rather than the absolute `glitchwerks/github-actions/claude-command-router@v2` pattern used elsewhere. This is intentional — the router is only ever called from reusable workflows *within this library* after `actions/checkout@v4` has already checked out the library's own code, so the relative path resolves correctly. External consumers never reference the router directly; they go through `claude-tag-respond.yml`. The absolute-ref convention in CLAUDE.md applies to actions exposed to external consumers; internal-only plumbing can safely use relative paths.
+**Absolute-ref note** _(amended Phase 5 — see Phase 5 PR #189):_ The router is invoked as `glitchwerks/github-actions/claude-command-router@v2` (absolute), matching the CLAUDE.md "absolute refs, not relative paths" convention. The earlier proposal of `./claude-command-router` (relative) was unsound: when an external consumer's caller workflow invokes `claude-tag-respond.yml@v2`, `actions/checkout@v4` defaults to `${{ github.repository }}` — the **consumer's** repo — and `./claude-command-router` does not resolve there. Absolute refs let GitHub fetch the action directly from this library's tree without a local checkout.
+
+**Single-expression `container:`** _(amended Phase 5):_ The `container:` field receives a single fully-resolved expression (`${{ needs.route.outputs.image }}`) rather than concatenating `overlay` and a digest inline, because the digest differs per overlay and there is no GHA mechanism to compute it inside the field. The `route` job's `image` step encapsulates the overlay → digest mapping; Phase 6's promotion-PR automation only needs to edit that case statement.
 
 (See Section 13 open question #2 regarding `container:` expression support at job level.)
 


### PR DESCRIPTION
## Summary

Phase 5 of the CI Claude Runtime epic (#130). Wires the Phase 3 overlay images into every consumer-facing reusable workflow via `container: ghcr.io/.../claude-runtime-<verb>@sha256:<digest>` at job level, and replaces the v2 `tag-claude/`-backed `claude-tag-respond.yml` with a router/dispatch flow that uses the Phase 4 `claude-command-router/`.

Closes #188 (Phase 5 sub-issue). Refs #130 (epic).

## Files

| File | Change | Container |
|---|---|---|
| `.github/workflows/claude-pr-review.yml` | Modified — add `container:` | `claude-runtime-review` |
| `.github/workflows/claude-apply-fix.yml` | **New** reusable form (alongside `apply-fix.yml`) | `claude-runtime-fix` |
| `.github/workflows/claude-lint-failure.yml` | **New** reusable form (alongside `claude-lint-fix.yml`) | `claude-runtime-fix` |
| `.github/workflows/claude-ci-failure.yml` | **New** reusable form (alongside `ci-failure.yaml`) | `claude-runtime-fix` |
| `.github/workflows/claude-tag-respond.yml` | Full rewrite — two-job `route` → `dispatch` | *routed* (review/fix/explain) |
| `CLAUDE.md` | Updated Architecture → CI automation workflows section | — |
| `README.md` | Added Phase 5 wiring callout under "CI runtime" | — |

The legacy workflows (`claude-lint-fix.yml`, `apply-fix.yml`, `ci-failure.yaml`, plus the `tag-claude/` composite action) stay in place until Phase 7 cutover so external consumers aren't broken mid-epic.

## Digest source

All four pins resolve digests captured from Phase 3 STAGE 3 build run [25261308990](https://github.com/glitchwerks/github-actions/actions/runs/25261308990) at `c8d9b7e` (Phase 3 merge):

| Image | Digest |
|---|---|
| `claude-runtime-review` | `sha256:776980ed9009fe17dfdb782960978bd573842dc867728bd4e63d734871cdeef1` |
| `claude-runtime-fix` | `sha256:da2b6e52ad20159252cb6f24147d4ece221182dbb0b21df9fb32966126e24a20` |
| `claude-runtime-explain` | `sha256:23dd59f2651ebc9aba93b5c143d5b78d256c8abe1ebf970ad9c218f6aa06ff77` |

The `fix` digest is referenced in three workflows (`claude-apply-fix.yml`, `claude-lint-failure.yml`, `claude-ci-failure.yml`) and one branch of the `claude-tag-respond.yml` lookup; the `claude-runtime-fix` package's GHCR garbage collector treats any of those references as a strong root.

## §13 verifications

### Q2 — `container:` expression support at job level

**Outcome:** ✅ Single dispatch job, no discrete-jobs fallback needed.

The GitHub Actions [context-availability table](https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability) lists `needs` as available for `jobs.<job_id>.container.image`. The `claude-tag-respond.yml` `dispatch` job uses `container: ${{ needs.route.outputs.image }}` — a single fully-resolved expression that GHA resolves at job-start time. The mapping from `overlay → image URL` lives in a small lookup step inside `route`, which keeps the router composite action pure (no awareness of digests) and lets Phase 6's promotion-PR automation update digests by editing only the `route` job's case statement.

If runtime evidence later contradicts the docs, the fallback is three discrete `dispatch-<verb>` jobs gated by `if: needs.route.outputs.overlay == '<verb>'` — but that is not implemented today.

### Q3 — `claude-code-action` `executable_path`

**Outcome:** ✅ Documented input present (named `path_to_claude_code_executable`), but Phase 5 stays on env-only.

Reviewed `anthropics/claude-code-action@v1`'s [action.yml inputs](https://github.com/anthropics/claude-code-action/blob/main/action.yml) — `path_to_claude_code_executable` is documented (input #29). The runtime image's Dockerfile sets `ENV PATH_TO_CLAUDE_CODE_EXECUTABLE=/opt/claude/bin/claude`, which `claude-code-action` reads automatically; threading the input explicitly through every composite (`pr-review/`, `apply-fix/`, `lint-failure/`, the dispatch step in `claude-tag-respond.yml`) would expand Phase 5 scope without changing behavior. Revisit if a future overlay needs a non-default path.

## §13 Q2 implementation note — single-expression `container:`

The naive `container: ghcr.io/glitchwerks/claude-runtime-${{ overlay }}@sha256:???` doesn't work because the digest differs per overlay and there's no GHA mechanism to compute it inside the field. The approach here:

```yaml
route:
  outputs:
    image: ${{ steps.image.outputs.image }}
  steps:
    - id: r
      uses: glitchwerks/github-actions/claude-command-router@v2
      with:
        comment_body: ${{ github.event.comment.body }}
    - id: image
      run: |
        case "$OVERLAY" in
          review)  IMG="ghcr.io/...claude-runtime-review@sha256:..." ;;
          fix)     IMG="ghcr.io/...claude-runtime-fix@sha256:..." ;;
          explain) IMG="ghcr.io/...claude-runtime-explain@sha256:..." ;;
        esac
        echo "image=$IMG" >> "$GITHUB_OUTPUT"

dispatch:
  needs: route
  container: ${{ needs.route.outputs.image }}
```

Single field, no concatenation in `container:`, single dispatch job.

## Spec deviation: relative-path note in §8.2

Spec §8.2 example shows `uses: ./claude-command-router` for the `route` job, justifying it as "internal-only plumbing". This works for dogfood (this repo) but breaks for external consumers — when a consumer's `claude-tag-respond.yml@v2` runs, `actions/checkout@v4` defaults to checking out the **consumer's** repo, where `./claude-command-router` does not exist.

This PR uses `glitchwerks/github-actions/claude-command-router@v2` (absolute ref), matching the CLAUDE.md "absolute refs, not relative paths" convention for any action reachable from a workflow that external consumers invoke. The `uses:` line is in-tree comments-documented at the top of `claude-tag-respond.yml`.

## Acceptance

- [x] All five reusable workflows container-pinned by digest
- [x] Q2 outcome recorded (expression-based, single dispatch job)
- [x] Q3 outcome recorded (env-only, documented decision)
- [x] `actionlint -shellcheck="-S info"` clean on all modified workflows
- [x] README + CLAUDE.md updated with Phase 5 wiring + Phase 7 migration note
- [ ] CI green
- [ ] This repo's own next PR exercises `claude-pr-review.yml` against the new review overlay (post-merge dogfood — task 5.9)

## Test plan

- [ ] `lint.yml` (actionlint) green
- [ ] `tests.yml` (router corpus) green
- [ ] `claude-pr-review.yml` triggers on this PR via `pull_request_target` and runs against the **base branch's** workflow (still v2 today, so this PR's `container:` change won't apply until merge — per CLAUDE.md "Dogfooding limitation"). Verifying that pre-merge review still works confirms we haven't accidentally broken the v2 path.
- [ ] After merge: open a no-op follow-up PR and observe `claude-pr-review.yml` runs inside the review container; capture transcript for the §10.5 feedback signal mentioned in plan task 5.9.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_