### PR TITLE
feat(ci): periodic overlay-image-pull smoke test

### DIFF
--- a/.github/workflows/overlay-smoke.yml
+++ b/.github/workflows/overlay-smoke.yml
@@ -1,0 +1,124 @@
+name: Overlay Image Smoke Test
+
+# Periodic pull-verify for the three digest-pinned overlay images.
+# Gap closed: GHCR can lose a layer or a future digest bump can typo; this
+# workflow catches the breakage before a user PR is affected.
+# Issue: #190
+#
+# Digest source-of-truth: the existing `claude-*.yml` workflow files — grepped
+# at runtime so this workflow never owns a separate copy that could drift.
+# The three overlays are: review, fix, explain.
+
+on:
+  schedule:
+    # Daily at 06:17 UTC — off-peak, avoids the hour mark to reduce collision
+    # with other repos' scheduled jobs.
+    - cron: '17 6 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  smoke:
+    name: Pull overlay images
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        overlay: [review, fix, explain]
+    steps:
+      - name: Checkout (for workflow file digest grep)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 1
+
+      - name: Resolve digest for overlay
+        id: digest
+        shell: bash
+        env:
+          OVERLAY: ${{ matrix.overlay }}
+        run: |
+          set -euo pipefail
+          # Grep all workflow files for lines referencing this overlay image and
+          # extract the @sha256:<hex> suffix.  The authoritative pins live in
+          # claude-pr-review.yml (review), claude-apply-fix.yml (fix), and
+          # claude-tag-respond.yml (explain / all three in the case block).
+          IMG=$(grep -rh "claude-runtime-${OVERLAY}@sha256:" .github/workflows/ \
+                  | grep -oE 'ghcr\.io/glitchwerks/claude-runtime-[^@]+@sha256:[a-f0-9]+' \
+                  | sort -u \
+                  | head -n1)
+          if [ -z "$IMG" ]; then
+            echo "::error::No digest found for overlay '${OVERLAY}' in .github/workflows/"
+            exit 1
+          fi
+          echo "image=${IMG}" >> "$GITHUB_OUTPUT"
+          echo "Resolved: ${IMG}"
+
+      - name: Docker pull overlay image
+        id: pull
+        shell: bash
+        env:
+          IMAGE: ${{ steps.digest.outputs.image }}
+        run: |
+          set -euo pipefail
+          echo "Pulling: ${IMAGE}"
+          docker pull "${IMAGE}"
+          echo "Pull succeeded."
+
+      - name: Report failure and dedup issue
+        if: failure() && steps.pull.outcome == 'failure'
+        shell: bash
+        # shellcheck disable=SC2016
+        env:
+          GH_TOKEN: ${{ github.token }}
+          OVERLAY: ${{ matrix.overlay }}
+          IMAGE: ${{ steps.digest.outputs.image }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          TITLE="Overlay smoke test failed: ${OVERLAY}"
+          # Search for an existing open issue with this exact title to avoid
+          # creating one per-run. Title is stable (no digest/run id) so the
+          # dedup key is consistent across failures for the same overlay.
+          EXISTING_NUMBER=$(gh issue list \
+            --state open \
+            --search "\"${TITLE}\" in:title" \
+            --json number,title \
+            --jq ".[] | select(.title == \"${TITLE}\") | .number" \
+            | head -n1)
+
+          BODY="$(cat <<EOF
+          **Overlay:** \`${OVERLAY}\`
+          **Image:** \`${IMAGE}\`
+          **Run:** ${RUN_URL}
+
+          The \`docker pull\` for this digest-pinned overlay failed, which means consumer
+          workflows that use this overlay will also fail. Possible causes:
+          - A GHCR layer was garbage-collected or corrupted
+          - The digest pin in a \`claude-*.yml\` workflow file contains a typo
+          - GHCR experienced a transient outage (re-run the smoke workflow to verify)
+
+          **Next steps:** check the run log at the URL above for the exact Docker error,
+          then rebuild the affected overlay via \`.github/workflows/runtime-build.yml\`
+          and update the digest pin.
+          EOF
+          )"
+
+          if [ -z "$EXISTING_NUMBER" ]; then
+            gh issue create \
+              --title "${TITLE}" \
+              --body "${BODY}" \
+              --label "bug"
+          else
+            gh issue comment "${EXISTING_NUMBER}" \
+              --body "$(cat <<EOF
+          Smoke test still failing (run: ${RUN_URL})
+
+          **Image:** \`${IMAGE}\`
+          EOF
+              )"
+          fi
+          # Always exit non-zero so the run is marked failed.
+          exit 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,8 @@ The build workflow `.github/workflows/runtime-build.yml` runs STAGE 1 on `pull_r
 
 **Phase 5 image refresh (post-#194):** PR [#195](https://github.com/glitchwerks/github-actions/pull/195) rebuilt the runtime base image with `unzip` and `gh` baked in, producing new overlay digests on the post-merge `runtime-build` run (run id 25398539323); the five container-pinned reusable workflows and the `claude-tag-respond.yml` dispatch mapping were repointed to those new digests in PR-B of [#194](https://github.com/glitchwerks/github-actions/issues/194). The underlying overlay set, layer model, and "different eyes" guarantee are unchanged.
 
+**Overlay smoke test (`overlay-smoke.yml`):** `.github/workflows/overlay-smoke.yml` runs daily (06:17 UTC) and on `workflow_dispatch`. It greps the digest pins directly from existing `claude-*.yml` workflow files (no separate source-of-truth copy that could drift) and attempts a `docker pull` for each of the three overlays. If a pull fails, the workflow opens a deduped GitHub issue titled `Overlay smoke test failed: <verb>` — or appends a comment to the existing open issue — and exits non-zero so the run shows as failed. To triage a failure: check the Actions run log for the Docker error, then rebuild the affected overlay via `runtime-build.yml` and update the digest pin in the relevant `claude-*.yml` workflow file. Issue [#190](https://github.com/glitchwerks/github-actions/issues/190).
+
 ## Versioning
 
 - `v2.0.0` — pinned tag for reproducible builds


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/overlay-smoke.yml` — runs daily at 06:17 UTC and on `workflow_dispatch`; attempts `docker pull` for each of the three digest-pinned overlay images (`review`, `fix`, `explain`)
- Digests are grepped at runtime from the existing `claude-*.yml` workflow files — no separate list to drift
- On failure: opens a deduped GitHub issue titled `Overlay smoke test failed: <verb>` (or appends a comment to the existing open issue); workflow exits non-zero so the run shows as failed
- Documents the smoke workflow in `CLAUDE.md` § CI Runtime (Phase 1+)

## Test plan

- [ ] Push triggers `actionlint` lint check — should pass (verified locally: zero errors)
- [ ] Manually trigger `overlay-smoke` workflow via `workflow_dispatch` to confirm all three pulls succeed on current digests
- [ ] Verify matrix shows three parallel jobs: `review`, `fix`, `explain`
- [ ] To test failure path: temporarily edit a digest pin to an invalid SHA, trigger manually, confirm an issue is opened titled `Overlay smoke test failed: <verb>`

Closes #190

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_