### PR TITLE
fix(runtime): add unzip + gh to base image

### DIFF
--- a/runtime/base/Dockerfile
+++ b/runtime/base/Dockerfile
@@ -31,12 +31,30 @@ LABEL org.opencontainers.image.source="https://github.com/glitchwerks/github-act
 # Minimum runtime deps. Combine RUN steps to shrink layer count.
 # `git` and `curl` are needed by the Claude Code CLI install path; `ca-certificates`
 # for HTTPS; `jq` is required by smoke-test.sh's structured-output parser.
+# `unzip` is required by `oven-sh/setup-bun@v1` (transitively used by
+# `claude-code-action@v1`) to extract its tarball.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       ca-certificates \
       curl \
       git \
       jq \
+      unzip \
+ && rm -rf /var/lib/apt/lists/*
+
+# Install GitHub CLI (`gh`) from the official cli.github.com apt repo.
+# Required by composite actions in this repo (pr-review, apply-fix, lint-failure,
+# ci-failure, tag-claude) — they shell out to `gh` for PR diff fetching, status
+# creation, comment posting, and dedup. claude-code-action@v1 also exposes gh
+# subcommands to the AI via --allowedTools (Bash(gh pr diff:*), Bash(gh pr review:*),
+# Bash(gh pr view:*)). See issue #194 for the full call-site map.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+      -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+ && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+      > /etc/apt/sources.list.d/github-cli.list \
+ && apt-get update \
+ && apt-get install -y --no-install-recommends gh \
  && rm -rf /var/lib/apt/lists/*
 
 # Install Claude Code CLI at the pinned version. The version flows from the


### PR DESCRIPTION
## Summary

PR-A of the two-PR sequence described in issue #194 (#193 was the immediately-prior hotfix that exposed this failure layer).

**One file changed:** `runtime/base/Dockerfile`

The Phase 2 base image was missing two binaries that consumer composite actions hard-depend on:

- **`unzip`** — added to the existing `apt-get install` step (alphabetically between `jq` and the cleanup line). Required by `oven-sh/setup-bun@v1`, which is invoked during the setup phase of `anthropics/claude-code-action@v1` to extract its tarball. Without it the action fails with `Unable to locate executable file: unzip` before the review body even runs (observed on PR #191 after #193 merged).

- **`gh`** — added as a separate `RUN` step using the canonical `cli.github.com/packages` keyring + `sources.list` pattern (no deprecated `apt-key add`). Required by composite actions at 14+ call sites across `pr-review/`, `apply-fix/`, `lint-failure/`, `ci-failure/`, and `tag-claude/` (PR diff fetching, status creation, comment posting, dedup). `claude-code-action@v1` also exposes `gh` subcommands to the AI via `--allowedTools`.

Both layers are placed **before** `COPY shared/` and `npm install -g` so they cache independently of manifest content churn.

Overlay Dockerfiles (`runtime/overlays/{review,fix,explain}/Dockerfile`) are not modified — they all inherit from base, so this single change covers all three overlays.

## Local verification output

```
$ docker run --rm --entrypoint sh claude-runtime-base:test \
    -c 'which unzip && which gh && unzip -v | head -1 && gh --version | head -1'
/usr/bin/unzip
/usr/bin/gh
UnZip 6.00 of 20 April 2009, by Debian. Original by Info-ZIP.
gh version 2.92.0 (2026-04-28)
```

`docker build` exited 0. Both binaries verified present in the built image.

## Test plan

- [ ] STAGE 4-overlay smoke tests pass (CI `runtime-build` workflow validates rebuilt image)
- [ ] `actionlint` passes (no workflow files changed in this PR)
- [ ] After merge, `runtime-build` on main produces new overlay digests for PR-B

## Closing note

This PR uses `Refs #194`, NOT `Closes #194` — issue #194 closes when PR-B lands with the updated digest pins in the 5 container-pinned reusable workflows.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_