### PR TITLE
ci(workflows): pin post-#200 overlay digests (closes #201)

### DIFF
--- a/.github/workflows/claude-apply-fix.yml
+++ b/.github/workflows/claude-apply-fix.yml
@@ -39,8 +39,8 @@ jobs:
     runs-on: ubuntu-latest
     # Phase 5: pin the fix overlay image by SHA256 digest. The fix overlay
     # carries the agent set required for code-write tasks (per spec §7.5).
-    # Digest source: runtime-build run 25398539323 (post-#195 rebuild, unzip+gh baked in).
-    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:3e8fd1b77b5e92c83f759059fc76c764f84f3d85ca14df3af4c27979febded24
+    # Digest source: STAGE 3 build run 25405636887 (post-#200 rebuild, 3bb6a22) — base image bakes safe.directory '*' (#199, #197).
+    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:2474e5ce130dca5db44088a5cf1bc22999c0944abf065df47999b018b838b286
     concurrency:
       group: claude-apply-fix-${{ github.repository }}-${{ inputs.pr_number }}
       cancel-in-progress: false

--- a/.github/workflows/claude-ci-failure.yml
+++ b/.github/workflows/claude-ci-failure.yml
@@ -56,8 +56,8 @@ jobs:
     # uses the fix overlay (per §7.5) rather than a dedicated diagnose overlay
     # — the same agent set handles read-only and apply paths, behavior is
     # gated by the `auto_apply` input passed to the prompt.
-    # Digest source: runtime-build run 25398539323 (post-#195 rebuild, unzip+gh baked in).
-    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:3e8fd1b77b5e92c83f759059fc76c764f84f3d85ca14df3af4c27979febded24
+    # Digest source: STAGE 3 build run 25405636887 (post-#200 rebuild, 3bb6a22) — base image bakes safe.directory '*' (#199, #197).
+    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:2474e5ce130dca5db44088a5cf1bc22999c0944abf065df47999b018b838b286
     concurrency:
       group: claude-ci-failure-${{ github.repository }}-${{ inputs.pr_number }}
       cancel-in-progress: true

--- a/.github/workflows/claude-lint-failure.yml
+++ b/.github/workflows/claude-lint-failure.yml
@@ -57,8 +57,8 @@ jobs:
     # the fix overlay handles both read-only diagnosis (auto_apply: false)
     # and the auto-apply path (auto_apply: true) — the composite action's
     # behavior switches on the input, the image does not.
-    # Digest source: runtime-build run 25398539323 (post-#195 rebuild, unzip+gh baked in).
-    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:3e8fd1b77b5e92c83f759059fc76c764f84f3d85ca14df3af4c27979febded24
+    # Digest source: STAGE 3 build run 25405636887 (post-#200 rebuild, 3bb6a22) — base image bakes safe.directory '*' (#199, #197).
+    container: ghcr.io/glitchwerks/claude-runtime-fix@sha256:2474e5ce130dca5db44088a5cf1bc22999c0944abf065df47999b018b838b286
     concurrency:
       group: claude-lint-failure-${{ github.repository }}-${{ inputs.pr_number }}
       cancel-in-progress: true

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -45,8 +45,8 @@ jobs:
     # invocation all run inside this container. The image bakes in Claude CLI
     # at $PATH_TO_CLAUDE_CODE_EXECUTABLE plus the review-specific agent set
     # (different-eyes guarantee per spec §3.1, §10.2).
-    # Digest source: runtime-build run 25398539323 (post-#195 rebuild, unzip+gh baked in).
-    container: ghcr.io/glitchwerks/claude-runtime-review@sha256:e0bb9972fb1273bb6cd4fa4e2db06834eb65fe88563477a6933832647c2184ca
+    # Digest source: STAGE 3 build run 25405636887 (post-#200 rebuild, 3bb6a22) — base image bakes safe.directory '*' (#199, #197).
+    container: ghcr.io/glitchwerks/claude-runtime-review@sha256:46d16c22e19dcd98bea17827334c28dd0d6f3a97e6c631816fe5741024081aeb
     concurrency:
       group: claude-pr-review-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: true

--- a/.github/workflows/claude-tag-respond.yml
+++ b/.github/workflows/claude-tag-respond.yml
@@ -86,7 +86,7 @@ jobs:
       # image names or digests) and lets `dispatch` consume a single
       # already-resolved string in `container:`. Updating the digest pins on
       # promotion (Phase 6, #143) only touches this lookup table.
-      # Digest source: STAGE 3 build run 25261308990 (Phase 3 merge, c8d9b7e).
+      # Digest source: STAGE 3 build run 25405636887 (post-#200 rebuild, 3bb6a22) — base image bakes safe.directory '*' (#199, #197).
       - id: image
         if: steps.r.outputs.status == 'ok'
         shell: bash
@@ -96,13 +96,13 @@ jobs:
           set -euo pipefail
           case "$OVERLAY" in
             review)
-              IMG="ghcr.io/glitchwerks/claude-runtime-review@sha256:e0bb9972fb1273bb6cd4fa4e2db06834eb65fe88563477a6933832647c2184ca"
+              IMG="ghcr.io/glitchwerks/claude-runtime-review@sha256:46d16c22e19dcd98bea17827334c28dd0d6f3a97e6c631816fe5741024081aeb"
               ;;
             fix)
-              IMG="ghcr.io/glitchwerks/claude-runtime-fix@sha256:3e8fd1b77b5e92c83f759059fc76c764f84f3d85ca14df3af4c27979febded24"
+              IMG="ghcr.io/glitchwerks/claude-runtime-fix@sha256:2474e5ce130dca5db44088a5cf1bc22999c0944abf065df47999b018b838b286"
               ;;
             explain)
-              IMG="ghcr.io/glitchwerks/claude-runtime-explain@sha256:c3fb56ee7bd95177ad7658a953035c40071b797187f48e215d90e8a2f31f424c"
+              IMG="ghcr.io/glitchwerks/claude-runtime-explain@sha256:6eb12b4aeca5873e329b6c0542509d87b2dd17eec58ffc3fec47291954c4ff80"
               ;;
             *)
               echo "::error::router emitted status=ok but overlay=$OVERLAY is not in the known set (review|fix|explain). Add the new overlay to the case statement in the 'image' step of the route job (.github/workflows/claude-tag-respond.yml)."


### PR DESCRIPTION
## Summary

- Bumps all 7 overlay digest pins in the five container-pinned reusable workflows to the post-#200 rebuild digests (runtime-build run 25405636887, commit 3bb6a22)
- Updates provenance comments in all five files to cite the new run and the safe.directory fix (#199, #197)
- No logic changes — pure digest promotion

## Substitution map

| Overlay | Old digest (prefix) | New digest (prefix) | Files (count) |
|---------|--------------------|--------------------|---------------|
| review  | `e0bb997…` | `46d16c2…` | `claude-pr-review.yml`, `claude-tag-respond.yml` (2) |
| fix     | `3e8fd1b…` | `2474e5c…` | `claude-apply-fix.yml`, `claude-ci-failure.yml`, `claude-lint-failure.yml`, `claude-tag-respond.yml` (4) |
| explain | `c3fb56e…` | `6eb12b4…` | `claude-tag-respond.yml` (1) |

Total: 7 substitutions across 5 files.

## Verification results

```
=== Old digests (must be 0) ===
(grep exited 1 — no matches found across all workflow files)

=== New digests ===
Review:  2
Fix:     4
Explain: 1
```

`actionlint` — no output (clean).

`git diff --stat` — exactly 5 files changed, no other files touched.

## Test plan

- [x] `actionlint .github/workflows/*.yml` — passes with no output
- [x] Hash-count verification — 0 old digests, 2 review + 4 fix + 1 explain = 7 new
- [x] `git diff --stat` — exactly 5 workflow files changed
- [ ] Fresh-PR dogfood: open a PR against this repo after merge and confirm `claude-pr-review` job starts successfully inside the new review overlay (safe.directory no longer blocks git)

Closes #201

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_