### PR TITLE
fix(rollback): enumerate persona before inventory-match

### DIFF
--- a/.github/workflows/runtime-rollback.yml
+++ b/.github/workflows/runtime-rollback.yml
@@ -169,19 +169,42 @@ jobs:
           sudo chmod +x /usr/local/bin/yq
 
       - name: Validate target digests via inventory-match (Step 6.3.5b)
+        env:
+          SMOKE_UID: ${{ steps.uid.outputs.uid }}
         run: |
           set -euo pipefail
           # Rolled-back digests must satisfy each overlay's expected.yaml
           # inventory contract — same check STAGE 4-overlay smoke runs at
           # build time. Catches rollback targets that were valid when built
           # but no longer satisfy current expectations.
-          chmod +x runtime/scripts/inventory-match.sh
+          #
+          # IMPORTANT: inventory-match.sh expects a LOCAL JSON FILE (output of
+          # enumerate-persona.sh), not an image URL. The broken original call
+          # passed the image URL as $1, causing immediate ERROR enumeration_json_not_found.
+          # Fix (#213): enumerate first into a temp file, then pass that file.
+          chmod +x runtime/scripts/inventory-match.sh runtime/scripts/enumerate-persona.sh
           for ov in review fix explain; do
             upper=$(echo "$ov" | tr '[:lower:]' '[:upper:]')
             eval "DIGEST=\${${upper}_DIGEST}"
+            IMAGE_URL="ghcr.io/glitchwerks/claude-runtime-${ov}@sha256:${DIGEST}"
+            ENUM_OUT=$(mktemp)
+            enum_rc=0
+            IMAGE_REF="$IMAGE_URL" SMOKE_UID="$SMOKE_UID" \
+              bash runtime/scripts/enumerate-persona.sh "$ENUM_OUT" || enum_rc=$?
+            if [ "$enum_rc" -ne 0 ]; then
+              echo "::error::enumerate-persona failed for overlay $ov (image=$IMAGE_URL)" >&2
+              rm -f "$ENUM_OUT"
+              exit "$enum_rc"
+            fi
+            match_rc=0
             bash runtime/scripts/inventory-match.sh \
-              "ghcr.io/glitchwerks/claude-runtime-${ov}@sha256:${DIGEST}" \
-              "runtime/overlays/${ov}/expected.yaml"
+              "$ENUM_OUT" \
+              "runtime/overlays/${ov}/expected.yaml" || match_rc=$?
+            rm -f "$ENUM_OUT"
+            if [ "$match_rc" -ne 0 ]; then
+              echo "::error::inventory-match failed for overlay $ov (image=$IMAGE_URL)" >&2
+              exit "$match_rc"
+            fi
           done
 
       - name: Validate target digests via smoke-test (Step 6.3.5c)


### PR DESCRIPTION
## Summary

Closes #213

Step 6.3.5b in `.github/workflows/runtime-rollback.yml` was passing the image URL directly as `$1` to `runtime/scripts/inventory-match.sh`. That script's contract (line 36) requires a **local JSON file** — the output of `enumerate-persona.sh`. Passing a URL caused an immediate `ERROR enumeration_json_not_found` at line 39, failing every rollback dispatch.

- Add `enumerate-persona.sh` call per overlay inside the loop, writing to a `mktemp` file
- Pass the temp file (not the image URL) as `$1` to `inventory-match.sh`
- Forward `SMOKE_UID` from `steps.uid.outputs.uid` via the step `env:` block (required by `enumerate-persona.sh`)
- Mirrors the established pattern in `runtime/scripts/overlay-smoke.sh` lines 66–74

## Verification

- **YAML parse**: `python -c "import yaml; yaml.safe_load(open(...))"` — clean
- **actionlint**: `actionlint .github/workflows/runtime-rollback.yml` — no output (clean pass)
- **Manual diff review**: confirmed (a) `enumerate-persona.sh` called per overlay, (b) output captured to `mktemp` file, (c) that path passed as `$1` to `inventory-match.sh`, (d) `for ov in review fix explain` loop preserved, (e) all three overlays exercised
- shellcheck not on PATH; no SC2016 cases introduced (no `${{ }}` in single-quoted strings in the modified block)

## Post-merge follow-up

Once this lands, re-dispatch Task 6.9 rehearsal Step 6.9.4′ with `target_pubsha=b080630804cc5783be7060121a05db1b1523ad0f` (Set B — known-good, in promote history at commit `7a061b5`) to confirm the live fix. Step 6.3.5c (`Validate target digests via smoke-test`) was left untouched — it runs separately and provides complementary coverage via `smoke-test.sh`.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_