### PR TITLE
docs(examples): add drop-in caller workflow files for Phase 5 reusables

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,49 @@
+# Examples
+
+Drop-in caller workflows for `glitchwerks/github-actions` reusable workflows. Copy any of these to your repo's `.github/workflows/` directory, then customize.
+
+## Workflow index
+
+| File | Reusable workflow | Trigger | Secrets required |
+|---|---|---|---|
+| `claude-pr-review.yml` | `claude-pr-review.yml@v2` | `pull_request` (opened/synchronize/reopened/ready_for_review) | `CLAUDE_CODE_OAUTH_TOKEN` |
+| `claude-tag-respond.yml` | `claude-tag-respond.yml@v2` | `issue_comment`, `pull_request_review_comment` (created) | `CLAUDE_CODE_OAUTH_TOKEN`, `APP_ID`, `APP_PRIVATE_KEY` |
+| `claude-lint-failure.yml` | `claude-lint-failure.yml@v2` | `pull_request` — fires `notify-claude` job when `lint` fails | `CLAUDE_CODE_OAUTH_TOKEN`, `APP_ID`, `APP_PRIVATE_KEY` |
+| `claude-ci-failure.yml` | `claude-ci-failure.yml@v2` | `workflow_run` on completion of a named CI workflow | `CLAUDE_CODE_OAUTH_TOKEN`, `APP_ID`, `APP_PRIVATE_KEY` |
+| `claude-apply-fix.yml` | `claude-apply-fix.yml@v2` | `workflow_dispatch` (manual, three inputs) | `APP_ID`, `APP_PRIVATE_KEY` |
+
+## Before you start
+
+Three prerequisites must be in place before any of these examples will work:
+
+**(a) GitHub App installed on the consumer repo**
+
+Create (or reuse) a GitHub App with the following permissions:
+
+- Repository → Contents: Read and write
+- Repository → Pull requests: Read and write
+
+Install the App on the consumer repo and note its **App ID** and **private key (PEM)**.
+
+**(b) Secrets available as repo or org secrets**
+
+| Secret name | Used by |
+|---|---|
+| `CLAUDE_CODE_OAUTH_TOKEN` | All workflows (PR review, tag respond, lint failure, CI failure) |
+| `APP_ID` | Write-path workflows: tag respond, lint failure, CI failure, apply fix |
+| `APP_PRIVATE_KEY` | Same as above |
+
+Add these under **Settings → Secrets and variables → Actions** in the consumer repo, or at the org level if you want to share them across multiple repos.
+
+**(c) GHCR overlay packages accessible**
+
+All five Phase 5 reusable workflows pull a container image from `ghcr.io/glitchwerks/` before running. The runner authenticates the pull with `GITHUB_TOKEN`, so the packages must be reachable:
+
+- **Intra-`glitchwerks`-org repos:** set package visibility to **Internal** — all org repos get access automatically, no per-repo grant needed.
+- **External repos:** use the package settings page to add the consumer repo with role **Read** for each of the three packages (`claude-runtime-review`, `claude-runtime-fix`, `claude-runtime-explain`).
+
+In both cases, the caller workflow **must** declare `packages: read` at the workflow level (all five examples already do this). See the main README's [GHCR package access](../README.md#ghcr-package-access-for-org-wide-consumers) section for full instructions.
+
+## Full reference
+
+See the main [`README.md`](../README.md) for the complete API reference, permissions tables, token selection guidance, and troubleshooting notes.

--- a/examples/claude-apply-fix.yml
+++ b/examples/claude-apply-fix.yml
@@ -1,0 +1,45 @@
+# claude-apply-fix.yml — Manual unified-diff applier via workflow_dispatch
+#
+# Reusable workflow: glitchwerks/github-actions/.github/workflows/claude-apply-fix.yml@v2
+#
+# Prerequisites:
+#   - GitHub App installed on this repo with Contents r/w + Pull requests r/w
+#   - Secrets available: APP_ID, APP_PRIVATE_KEY
+#   - GHCR overlay packages accessible (Internal visibility or per-repo grant)
+#
+# To use: copy this file to .github/workflows/claude-apply-fix.yml, commit, push.
+# Trigger via the Actions tab → "Claude Apply Fix" → "Run workflow".
+
+name: Claude Apply Fix
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: 'PR number to apply the fix to'
+        type: string
+        required: true
+      fix_diff:
+        description: 'Unified diff string'
+        type: string
+        required: true
+      fix_description:
+        description: 'Commit message'
+        type: string
+        required: true
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: read
+
+jobs:
+  apply:
+    uses: glitchwerks/github-actions/.github/workflows/claude-apply-fix.yml@v2
+    with:
+      pr_number: ${{ inputs.pr_number }}
+      fix_diff: ${{ inputs.fix_diff }}
+      fix_description: ${{ inputs.fix_description }}
+    secrets:
+      app_id: ${{ secrets.APP_ID }}
+      app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/examples/claude-ci-failure.yml
+++ b/examples/claude-ci-failure.yml
@@ -1,0 +1,35 @@
+# claude-ci-failure.yml — CI failure diagnosis triggered via workflow_run
+#
+# Reusable workflow: glitchwerks/github-actions/.github/workflows/claude-ci-failure.yml@v2
+#
+# Prerequisites:
+#   - GitHub App installed on this repo with Contents r/w + Pull requests r/w
+#   - Secrets available: CLAUDE_CODE_OAUTH_TOKEN, APP_ID, APP_PRIVATE_KEY
+#   - GHCR overlay packages accessible (Internal visibility or per-repo grant)
+#
+# To use: copy this file to .github/workflows/claude-ci-failure.yml, commit, push.
+# IMPORTANT: Change `workflows: ["CI"]` below to match your CI workflow's `name:` field.
+
+name: Claude CI Failure Diagnosis
+
+on:
+  workflow_run:
+    workflows: ["CI"]  # change this to your CI workflow's name
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  packages: read
+
+jobs:
+  diagnose:
+    if: github.event.workflow_run.conclusion == 'failure'
+    uses: glitchwerks/github-actions/.github/workflows/claude-ci-failure.yml@v2
+    with:
+      pr_number: ${{ github.event.workflow_run.pull_requests[0].number }}
+      run_id: ${{ github.event.workflow_run.id }}
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      app_id: ${{ secrets.APP_ID }}
+      app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/examples/claude-lint-failure.yml
+++ b/examples/claude-lint-failure.yml
@@ -1,0 +1,45 @@
+# claude-lint-failure.yml — Lint failure diagnosis with optional auto-fix
+#
+# Reusable workflow: glitchwerks/github-actions/.github/workflows/claude-lint-failure.yml@v2
+#
+# Prerequisites:
+#   - GitHub App installed on this repo with Contents r/w + Pull requests r/w
+#   - Secrets available: CLAUDE_CODE_OAUTH_TOKEN, APP_ID, APP_PRIVATE_KEY
+#   - GHCR overlay packages accessible (Internal visibility or per-repo grant)
+#
+# To use: copy this file to .github/workflows/claude-lint-failure.yml, commit, push.
+# Replace the `npm run lint` step in the `lint` job with your actual linter command.
+
+name: Lint with Claude Diagnosis
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: read
+  packages: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run linter
+        run: npm run lint  # replace with your linter
+
+  notify-claude:
+    needs: [lint]
+    if: failure()
+    uses: glitchwerks/github-actions/.github/workflows/claude-lint-failure.yml@v2
+    with:
+      pr_number: ${{ github.event.pull_request.number }}
+      run_id: ${{ github.run_id }}
+      # auto_apply: true  # uncomment to allow Claude to commit a fix automatically
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      app_id: ${{ secrets.APP_ID }}
+      app_private_key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/examples/claude-pr-review.yml
+++ b/examples/claude-pr-review.yml
@@ -1,0 +1,27 @@
+# claude-pr-review.yml — Drop-in PR review caller
+#
+# Reusable workflow: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2
+#
+# Prerequisites:
+#   - GitHub App installed on this repo with Contents r/w + Pull requests r/w
+#   - Secrets available: CLAUDE_CODE_OAUTH_TOKEN
+#   - GHCR overlay packages accessible (Internal visibility or per-repo grant)
+#
+# To use: copy this file to .github/workflows/claude-pr-review.yml, commit, push.
+
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: write
+  packages: read
+
+jobs:
+  review:
+    uses: glitchwerks/github-actions/.github/workflows/claude-pr-review.yml@v2
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/examples/claude-tag-respond.yml
+++ b/examples/claude-tag-respond.yml
@@ -1,0 +1,32 @@
+# claude-tag-respond.yml — Drop-in @claude mention responder
+#
+# Reusable workflow: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@v2
+#
+# Prerequisites:
+#   - GitHub App installed on this repo with Contents r/w + Pull requests r/w
+#   - Secrets available: CLAUDE_CODE_OAUTH_TOKEN, APP_ID, APP_PRIVATE_KEY
+#   - GHCR overlay packages accessible (Internal visibility or per-repo grant)
+#
+# To use: copy this file to .github/workflows/claude-tag-respond.yml, commit, push.
+
+name: Claude Tag Respond
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  packages: read
+
+jobs:
+  respond:
+    uses: glitchwerks/github-actions/.github/workflows/claude-tag-respond.yml@v2
+    secrets:
+      claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+      app_id: ${{ secrets.APP_ID }}
+      app_private_key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

Closes #220.

Adds an `examples/` directory at repo root containing one ready-to-copy caller workflow per Phase 5 container-pinned reusable surface, plus a README index. Until now, consumers had to extract YAML out of fenced code blocks in the main README and hand-edit them inline. With #219 having corrected the README and this PR shipping ready-to-use templates, the consumer onboarding path becomes: read main README → copy the matching file from `examples/` → tweak two values (model, max_turns) → commit.

## Files added (6)

| File | Wraps | Trigger |
|---|---|---|
| `examples/claude-pr-review.yml` | `claude-pr-review.yml@v2` | `pull_request` |
| `examples/claude-tag-respond.yml` | `claude-tag-respond.yml@v2` | `issue_comment` + `pull_request_review_comment` |
| `examples/claude-lint-failure.yml` | `claude-lint-failure.yml@v2` | sibling `lint:` job + `if: failure()` |
| `examples/claude-ci-failure.yml` | `claude-ci-failure.yml@v2` | `workflow_run` on completed `CI` |
| `examples/claude-apply-fix.yml` | `claude-apply-fix.yml@v2` | `workflow_dispatch` with 3 inputs |
| `examples/README.md` | — | mini-index + prerequisites |

## Invariants

- All 5 `.yml` files declare `packages: read` at the workflow level (required by the implicit GHCR docker pull — same trap #192 documented).
- All 5 `uses:` lines pin to `@v2` (floating tag).
- Org-level secret names match the conventions in the main README (`CLAUDE_CODE_OAUTH_TOKEN`, `APP_ID`, `APP_PRIVATE_KEY`) — same `${{ secrets.X }}` syntax works for org-level or repo-level storage.
- Each `.yml` has a header comment block stating filename, the wrapped reusable, prerequisites, and copy-and-paste destination path.
- `actionlint` clean across all 5 files (zero warnings of any severity).

## Out of scope (follow-up)

- #221 — `docs/consumer-onboarding.md` end-to-end walkthrough (which will cross-link to `examples/README.md`).
- Adding a top-level "Examples" section to the main `README.md` linking here — deferred to #221 to keep this PR scoped to file additions.

## Test plan

- [x] `actionlint` clean on all 5 example workflows
- [x] `packages: read` present on every example
- [x] `@v2` pin on every `uses:` line
- [x] Commit on `issue-220-examples-folder`, not `main`
- [ ] Reviewer eye on whether the lint-failure two-job example accurately models the consumer flow (consumer's existing `lint:` job + a `notify-claude:` sibling)
- [ ] Reviewer eye on whether `claude-apply-fix.yml`'s input shape matches the reusable's actual input contract

## Cross-references

Builds on:
- #219 / #222 (README refresh — defines the contract these examples implement)

Followed by:
- #221 (consumer onboarding doc — will link to `examples/README.md`)

Milestone: #9 — Consumer onboarding hardening

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_