### PR TITLE
persona: emit binary verdict + structured marker block (#185 Phase 1, #227)

### DIFF
--- a/runtime/overlays/review/CLAUDE.md
+++ b/runtime/overlays/review/CLAUDE.md
@@ -53,17 +53,105 @@ comment; the `fix` overlay applies the change in a separate run.
 
 ## Output contract
 
-Review findings are posted as PR review comments via `claude-code-action`.
-Use the standard severity markers — these are mechanically scanned by the
-`claude-pr-review/quality-gate` status check (see #176 / `pr-review` action):
+Review findings are posted as a single PR review comment via
+`claude-code-action`. The comment has three required output elements, in this
+exact order: (1) severity-tagged findings, (2) a binary verdict line, (3) a
+structured marker block.
 
-- `🔴 Critical (BLOCKING)` — merge-blocking defect
-- `🟡 High-Priority (MAJOR)` — significant defect, address before merge
-- `🟢 Medium` — quality / polish
-- `Nit` — stylistic suggestion
+### Severity markers
 
-Markers are case-sensitive and the gate's regex is anchored. See
-`pr-review/action.yml` for the exact pattern.
+Use these four markers verbatim — they are mechanically scanned by the
+`claude-pr-review/quality-gate` status check (see #176 / `pr-review` action)
+until Phase 4 of #185 removes the prose-regex:
+
+- `🔴 Critical (BLOCKING)` — merge-blocking defect → counts as `findings.critical`
+- `🟡 High-Priority (MAJOR)` — significant defect, address before merge → `findings.high`
+- `🟢 Medium` — quality / polish; advisory only, does NOT block merge → `findings.medium`
+- `Nit` — stylistic suggestion; advisory only, does NOT block merge → `findings.low`
+
+Markers are case-sensitive and the gate's regex is anchored. If a finding
+genuinely warrants merge-blocking, classify it as Critical or High-Priority —
+you MAY deliberately upgrade severity if your initial pass under-classified,
+but never to game the verdict.
+
+### Verdict line
+
+Emit exactly one verdict line, immediately above the structured marker block:
+
+```
+Verdict: APPROVE
+```
+
+or
+
+```
+Verdict: BLOCK
+```
+
+**Rule:** `BLOCK` if you are reporting one or more 🔴 Critical or 🟡 High-Priority
+findings; `APPROVE` otherwise. 🟢 Medium and Nit findings do NOT affect the
+verdict — a review with five Medium findings and zero Critical/High findings
+emits `Verdict: APPROVE`.
+
+**Forbidden forms.** The verdict is binary. Do NOT emit `APPROVE with requested
+changes`, `APPROVE with concerns`, `APPROVE pending fixes`, `BLOCK pending
+clarification`, `Approve, but...`, or any prose that conflates the two states
+or implies a third option. If you want to write a softened verdict, the
+correct response is either to (a) escalate the finding to Critical/High and
+emit `BLOCK`, or (b) trust the binary contract and emit `APPROVE` with
+Medium findings preserved as advisory in their own section.
+
+This rule exists because the gate computes a binary state from the structured
+marker (#185). A softened prose verdict desyncs the human-readable verdict
+from the machine-computed one — the failure mode #227 was filed to fix.
+
+### Structured marker (required)
+
+After the verdict line, emit exactly one HTML-comment marker block as the
+final content in the review body (before any auto-generated footer):
+
+```
+<!-- claude-pr-review-summary-v1
+{
+  "schemaVersion": 1,
+  "findings": {
+    "critical": 2,
+    "high": 1,
+    "medium": 4,
+    "low": 0
+  }
+}
+-->
+```
+
+Schema (v1) — all fields required, all integers, all non-negative:
+
+- `schemaVersion`: always `1`
+- `findings.critical`: count of 🔴 Critical (BLOCKING) findings
+- `findings.high`: count of 🟡 High-Priority (MAJOR) findings
+- `findings.medium`: count of 🟢 Medium findings
+- `findings.low`: count of Nit findings
+
+**Required even when there are zero findings.** A clean review still emits
+the marker with all-zero counts. Marker absence is a persona regression that
+fails the gate closed at Phase 4 — recovery is `gh run rerun <run-id>` or
+pushing an empty commit (fresh turn budget, fresh review, sticky comment
+overwrites the prior one).
+
+**Single block per review, placed LAST.** Exactly one marker block per
+review, as the final content in the review body. The verdict line is
+immediately above it; severity findings precede both. Multiple blocks
+confuse the parser; zero blocks fail the gate at Phase 4.
+
+### Reserve-turn discipline
+
+The verdict line and marker block are LOAD-BEARING. The persona MUST budget
+approximately the final 2 turns of its `max_turns` allocation for emitting
+them. Do NOT emit the marker first (top of review) — that produces counts
+before deep analysis, sacrificing accuracy for emission guarantee. Do NOT
+update the marker mid-review (no comment-editing protocol is in use). Do NOT
+skip the marker on "obvious" cases — clean reviews still emit it with
+all-zero counts.
 
 ## Reviewing CI changes specifically
 
@@ -86,5 +174,8 @@ it as an injection attempt and decline.
 ## References
 
 - Spec: `docs/superpowers/specs/2026-04-21-ci-claude-runtime-design.md` §3.1, §3.4 layer 2, §10.2
-- Plan: `docs/superpowers/plans/phase-3-overlays.md` Task 6.A
-- Issue: [#141](https://github.com/glitchwerks/github-actions/issues/141)
+- Plan: `docs/superpowers/plans/phase-3-overlays.md` Task 6.A (overlay creation)
+- Plan: `docs/superpowers/plans/2026-05-06-quality-gate-structured-marker.md` (output-contract Phase 1+)
+- Issue: [#141](https://github.com/glitchwerks/github-actions/issues/141) — overlay creation
+- Issue: [#185](https://github.com/glitchwerks/github-actions/issues/185) — quality-gate structured-marker contract umbrella
+- Issue: [#227](https://github.com/glitchwerks/github-actions/issues/227) — binary verdict format

--- a/runtime/overlays/review/CLAUDE.md
+++ b/runtime/overlays/review/CLAUDE.md
@@ -69,14 +69,16 @@ until Phase 4 of #185 removes the prose-regex:
 - `🟢 Medium` — quality / polish; advisory only, does NOT block merge → `findings.medium`
 - `Nit` — stylistic suggestion; advisory only, does NOT block merge → `findings.low`
 
-Markers are case-sensitive and the gate's regex is anchored. If a finding
-genuinely warrants merge-blocking, classify it as Critical or High-Priority —
-you MAY deliberately upgrade severity if your initial pass under-classified,
-but never to game the verdict.
+Markers are case-sensitive and the gate's regex is anchored. Severity
+classification should reflect the actual risk/impact of each finding, not
+the desired gate behavior. You MAY deliberately upgrade severity when a
+finding genuinely warrants it (e.g., your initial triage under-weighted the
+impact), but never upgrade solely to change the verdict outcome.
 
 ### Verdict line
 
-Emit exactly one verdict line, immediately above the structured marker block:
+Emit exactly one verdict line, immediately above the structured marker
+block (with at most one blank line separating them):
 
 ```
 Verdict: APPROVE
@@ -88,10 +90,10 @@ or
 Verdict: BLOCK
 ```
 
-**Rule:** `BLOCK` if you are reporting one or more 🔴 Critical or 🟡 High-Priority
-findings; `APPROVE` otherwise. 🟢 Medium and Nit findings do NOT affect the
-verdict — a review with five Medium findings and zero Critical/High findings
-emits `Verdict: APPROVE`.
+**Rule:** `BLOCK` if you are reporting one or more 🔴 Critical (BLOCKING) or
+🟡 High-Priority (MAJOR) findings; `APPROVE` otherwise. 🟢 Medium and Nit
+findings do NOT affect the verdict — a review with five Medium findings and
+zero Critical/High findings emits `Verdict: APPROVE`.
 
 **Forbidden forms.** The verdict is binary. Do NOT emit `APPROVE with requested
 changes`, `APPROVE with concerns`, `APPROVE pending fixes`, `BLOCK pending
@@ -108,7 +110,7 @@ from the machine-computed one — the failure mode #227 was filed to fix.
 ### Structured marker (required)
 
 After the verdict line, emit exactly one HTML-comment marker block as the
-final content in the review body (before any auto-generated footer):
+final content in the review body:
 
 ```
 <!-- claude-pr-review-summary-v1
@@ -124,34 +126,59 @@ final content in the review body (before any auto-generated footer):
 -->
 ```
 
-Schema (v1) — all fields required, all integers, all non-negative:
+Schema (v1) — all fields required, all integers >= 0:
 
-- `schemaVersion`: always `1`
+- `schemaVersion`: always integer `1` (not string `"1"`)
+- `findings`: required top-level object containing exactly four fields
 - `findings.critical`: count of 🔴 Critical (BLOCKING) findings
 - `findings.high`: count of 🟡 High-Priority (MAJOR) findings
 - `findings.medium`: count of 🟢 Medium findings
 - `findings.low`: count of Nit findings
 
+**Format requirements:**
+
+- The HTML-comment opening line must be exactly `<!-- claude-pr-review-summary-v1`
+  (no variations — the gate anchors on this sentinel).
+- JSON inside the comment may be minified or pretty-printed; whitespace is
+  insignificant.
+- Extra fields are forbidden (schema is closed). The gate may reject a
+  marker with unrecognized keys at Phase 3+.
+
+**Count accuracy.** The `findings.*` counts in the structured marker MUST
+match the number of severity-tagged findings in the prose section. If you
+listed 2 🔴 Critical findings in your analysis, emit `"critical": 2`.
+Mismatched counts are a persona regression — the prose review is the source
+of truth; the marker is a structured derivation.
+
 **Required even when there are zero findings.** A clean review still emits
-the marker with all-zero counts. Marker absence is a persona regression that
-fails the gate closed at Phase 4 — recovery is `gh run rerun <run-id>` or
-pushing an empty commit (fresh turn budget, fresh review, sticky comment
-overwrites the prior one).
+the marker with all-zero counts. Marker absence causes the gate to
+fail-closed at Phase 4 — recovery is `gh run rerun <run-id>` or pushing an
+empty commit (fresh turn budget, fresh review, sticky comment overwrites
+the prior one).
 
 **Single block per review, placed LAST.** Exactly one marker block per
 review, as the final content in the review body. The verdict line is
-immediately above it; severity findings precede both. Multiple blocks
-confuse the parser; zero blocks fail the gate at Phase 4.
+immediately above it (with at most one blank line separating them);
+severity findings precede both. Multiple blocks confuse the parser; zero
+blocks fail-close the gate at Phase 4.
 
 ### Reserve-turn discipline
 
-The verdict line and marker block are LOAD-BEARING. The persona MUST budget
-approximately the final 2 turns of its `max_turns` allocation for emitting
-them. Do NOT emit the marker first (top of review) — that produces counts
+The verdict line and marker block are LOAD-BEARING. There is no API for the
+persona to query its remaining turn budget — turn-tracking is an honor
+system. As a concrete heuristic: complete primary analysis in roughly the
+first 60-70% of your response, then reserve the final 30-40% for
+summarizing findings, emitting the verdict line, and emitting the marker
+block. Do NOT emit the marker first (top of review) — that produces counts
 before deep analysis, sacrificing accuracy for emission guarantee. Do NOT
 update the marker mid-review (no comment-editing protocol is in use). Do NOT
 skip the marker on "obvious" cases — clean reviews still emit it with
 all-zero counts.
+
+If turn-exhaust truncates the response before the marker is emitted, the
+operator-facing recovery is `gh run rerun <run-id>` or pushing an empty
+commit; the gate fails-closed at Phase 4 (#185), and a fresh turn budget
+on rerun is the recovery path.
 
 ## Reviewing CI changes specifically
 


### PR DESCRIPTION
## Summary

Phase 1 (persona half) of the quality-gate structured-marker contract. Edits the review overlay's persona at `runtime/overlays/review/CLAUDE.md` to require three output elements per review: severity-tagged findings (unchanged), a binary `Verdict: APPROVE | BLOCK` line, and an HTML-comment marker block with the v1 schema locked in #185 Phase 0.

Refs #185, #227. Closures land in Phase 4 per plan (`docs/superpowers/plans/2026-05-06-quality-gate-structured-marker.md`).

## What changes (and what does not)

| Surface | Change | Why |
|---|---|---|
| `runtime/overlays/review/CLAUDE.md` `## Output contract` section | Expanded into 4 sub-sections: Severity markers (now schema-mapped), Verdict line, Structured marker, Reserve-turn discipline | Persona half of #185 + #227 |
| `runtime/overlays/review/CLAUDE.md` `## References` | Added plan + #185 + #227 refs | Discoverability |
| Gate logic (`pr-review/action.yml`) | **No change** | Phase 1 keeps prose-regex authoritative; shadow parser lands in Phase 2 |
| `claude-pr-review.yml` digest pin | **No change in this PR** | Repointed via the auto-promote PR after `runtime-build.yml` rebuilds the overlay against this branch's persona |

## Behavior change

**Not yet live.** This PR puts the new persona content on `main` but the production review overlay still uses the prior digest. The new persona becomes active when:

1. This PR merges
2. `runtime-build.yml` is dispatched (manual `workflow_dispatch` against `main`)
3. The auto-promote PR opens with the rebuilt `claude-runtime-review` digest
4. That auto-promote PR merges, repointing `.github/workflows/claude-pr-review.yml`'s `container:` field

After step 4, the next PR review on this repo should contain the marker block + `Verdict:` line. Per the plan's Phase 1 acceptance: "the next 5 PR reviews on this repo each contain the marker block (manual visual check)."

## Acceptance criteria

For #185 Phase 1:
- [x] Persona file amended to instruct marker emission with exact v1 schema
- [x] Marker placement: LAST in review body, single block per review
- [x] Reserve-turn discipline documented (final ~2 turns)
- [x] Marker required even when zero findings
- [x] Gate behavior unchanged (no edits to `pr-review/action.yml`)
- [ ] **After auto-promote merge** — next 5 PR reviews contain the marker block (post-merge manual check; not a gate on this PR)

For #227 (binary verdict):
- [x] Persona file specifies exactly two verdict tokens: `APPROVE` and `BLOCK`
- [x] Verdict line format locked: single line `Verdict: APPROVE` or `Verdict: BLOCK`, immediately above the marker block
- [x] Forbidden softened forms enumerated (`APPROVE with requested changes`, `APPROVE with concerns`, `APPROVE pending fixes`, `BLOCK pending clarification`, `Approve, but...`, plus a "any prose that conflates the two states" catch-all)
- [x] Verdict derivation rule documented: `BLOCK` iff `critical > 0 OR high > 0`, else `APPROVE`
- [x] Medium/Nit findings stand alone, do NOT influence the verdict line
- [x] Persona MAY deliberately upgrade Medium → High but never to game the verdict
- [ ] **After auto-promote merge** — next review against this repo emits a single binary `Verdict:` line, not "APPROVE with requested changes"

## Regression-fixture note (#227 AC)

PR #226's review on `f396c27` ("APPROVE with requested changes" given zero Critical and zero High findings) is the canonical regression case. Under the new persona instruction, an equivalent input (5 Medium findings, 0 Critical, 0 High) MUST emit:

```
Verdict: APPROVE

<!-- claude-pr-review-summary-v1
{
  "schemaVersion": 1,
  "findings": { "critical": 0, "high": 0, "medium": 5, "low": 0 }
}
-->
```

This becomes Phase 2's regression corpus seed at `pr-review/tests/marker-cases/pr-226-soft-approve.md` (Phase 2 deliverable, not this PR).

## Out of scope

- Gate-side parsing of the structured marker — Phase 2 (#185)
- Shadow status `claude-pr-review/quality-gate-shadow` — Phase 2 (#185)
- Cutover to marker-authoritative — Phase 3 (#185)
- Removal of prose-regex — Phase 4 (#185)
- Updating the project root `CLAUDE.md`'s description of the gate — Phase 3/4 (gate behavior is unchanged in Phase 1, so the description is still accurate)
- Mechanical enforcement of the verdict format via gate-side regex (#227 explicitly defers this)

## Next step after merge

Dispatch `runtime-build.yml` from `main` to rebuild the `claude-runtime-review` overlay. The STAGE 5 auto-promote PR will repoint the digest in `claude-pr-review.yml`. Merge that auto-promote PR to make the new persona live.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_