### PR TITLE
fix(overlay-smoke): authenticate against GHCR before docker pull

### DIFF
--- a/.github/workflows/overlay-smoke.yml
+++ b/.github/workflows/overlay-smoke.yml
@@ -19,6 +19,7 @@ on:
 permissions:
   contents: read
   issues: write
+  packages: read
 
 jobs:
   smoke:
@@ -55,6 +56,14 @@ jobs:
           fi
           echo "image=${IMG}" >> "$GITHUB_OUTPUT"
           echo "Resolved: ${IMG}"
+
+      - name: Log in to GHCR
+        shell: bash
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
       - name: Docker pull overlay image
         id: pull


### PR DESCRIPTION
## Root cause

When the overlay packages (`claude-runtime-review`, `claude-runtime-fix`, `claude-runtime-explain`) were flipped from Public to Internal on 2026-05-06, the `overlay-smoke.yml` workflow's bare `docker pull` steps started failing with `unauthorized`. The runner does not auto-authenticate explicit `docker pull` commands — it only issues an implicit `docker login` when a job declares `container: ghcr.io/...` at the job level.

## Fix

Two changes together:

1. **`packages: read` added to `permissions:`** — grants `GITHUB_TOKEN` the scope needed to read Internal GHCR packages.
2. **New `Log in to GHCR` step** inserted before `Docker pull overlay image` — authenticates the Docker daemon using `GITHUB_TOKEN` via stdin (never on the command line).

The login step uses the canonical `--password-stdin` form to avoid the token appearing in process arguments or runner logs.

## Test plan

- [x] After merge, run `workflow_dispatch` on `.github/workflows/overlay-smoke.yml`
- [ ] Expect all three matrix legs (`review`, `fix`, `explain`) to pass the `docker pull` step
- [ ] Confirm no new dedup issues are opened for the overlay smoke failure

Closes #235

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_