### PR TITLE
chore(deps): bump actions/checkout @v5 → @v6 (#231)

### DIFF
--- a/.github/workflows/apply-fix.yml
+++ b/.github/workflows/apply-fix.yml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout repo (needed to resolve local composite action)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Apply fix via composite action
         uses: ./apply-fix

--- a/.github/workflows/ci-failure.yaml
+++ b/.github/workflows/ci-failure.yaml
@@ -60,7 +60,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.token.outputs.value }}
           fetch-depth: 0

--- a/.github/workflows/claude-ci-failure.yml
+++ b/.github/workflows/claude-ci-failure.yml
@@ -85,7 +85,7 @@ jobs:
           fi
 
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.token.outputs.value }}
           fetch-depth: 0

--- a/.github/workflows/claude-tag-respond.yml
+++ b/.github/workflows/claude-tag-respond.yml
@@ -73,7 +73,7 @@ jobs:
       # Empty string when status != 'ok' (the lookup step is gated on status='ok').
       image:   ${{ steps.image.outputs.image }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - id: r
         uses: glitchwerks/github-actions/claude-command-router@v2
@@ -182,7 +182,7 @@ jobs:
             echo "value=${{ github.token }}" >> "$GITHUB_OUTPUT"
           fi
 
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.token.outputs.value }}
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,5 +9,5 @@ jobs:
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - uses: raven-actions/actionlint@v2

--- a/.github/workflows/marker-emission-aggregate.yml
+++ b/.github/workflows/marker-emission-aggregate.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/overlay-smoke.yml
+++ b/.github/workflows/overlay-smoke.yml
@@ -31,7 +31,7 @@ jobs:
         overlay: [review, fix, explain]
     steps:
       - name: Checkout (for workflow file digest grep)
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/runtime-build.yml
+++ b/.github/workflows/runtime-build.yml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -148,7 +148,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -259,7 +259,7 @@ jobs:
       marketplace_head: ${{ steps.clones.outputs.marketplace_head }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -338,7 +338,7 @@ jobs:
       marketplace_head: ${{ steps.clones.outputs.marketplace_head }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -477,7 +477,7 @@ jobs:
         overlay: [review, fix, explain]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -697,7 +697,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Login to GHCR (read)
         uses: docker/login-action@v4
@@ -744,7 +744,7 @@ jobs:
         overlay: [review, fix, explain]
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
 
       - name: Login to GHCR (read)
         uses: docker/login-action@v4
@@ -801,7 +801,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/runtime-check-private-freshness.yml
+++ b/.github/workflows/runtime-check-private-freshness.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout this repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/runtime-rollback.yml
+++ b/.github/workflows/runtime-rollback.yml
@@ -48,7 +48,7 @@ jobs:
       packages: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           # fetch-depth: 0 needed for the promote-history check below to walk
           # main's commits looking for an `auto/runtime-promote-<TARGET>` commit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/apply-fix/action.yml
+++ b/apply-fix/action.yml
@@ -43,7 +43,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ steps.token.outputs.value }}
         ref: refs/pull/${{ inputs.pr_number }}/head

--- a/lint-apply/action.yml
+++ b/lint-apply/action.yml
@@ -37,7 +37,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ steps.token.outputs.value }}
         fetch-depth: 0

--- a/lint-diagnose/action.yml
+++ b/lint-diagnose/action.yml
@@ -69,7 +69,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ steps.token.outputs.value }}
         fetch-depth: 0

--- a/lint-failure/action.yml
+++ b/lint-failure/action.yml
@@ -65,7 +65,7 @@ runs:
         fi
 
     - name: Checkout PR branch
-      uses: actions/checkout@v5
+      uses: actions/checkout@v6
       with:
         token: ${{ steps.token.outputs.value }}
         fetch-depth: 0

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -17,7 +17,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 

--- a/tag-claude/action.yml
+++ b/tag-claude/action.yml
@@ -72,7 +72,7 @@ runs:
           exit 1
         fi
 
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
       if: steps.authz.outputs.authorized == 'true'
       with:
         token: ${{ steps.token.outputs.value }}


### PR DESCRIPTION
## Summary

- Forward-maintenance dependency bump: `actions/checkout@v5` → `actions/checkout@v6` across all 17 source workflow and composite-action files (26 occurrences total)
- Deferred from #212 / PR #230 per scope-discipline rule (that PR was scoped to runtime image changes only)
- Plan files in `docs/superpowers/plans/` intentionally left at `@v5` — they are historical records, not live workflow code

## Upstream verification

actions/checkout v6 is a drop-in replacement for our usage. The only behavioral change relevant to this repo:

> `persist-credentials` now stores credentials in `$RUNNER_TEMP` instead of `.git/config`. Docker container actions need Actions Runner ≥ v2.329.0 to access the credential file — GitHub-hosted `ubuntu-latest` is well past that minimum, so there is no impact.

None of our `fetch-depth` / `ref` / `token` / `path` / `submodules` / `lfs` / `clean` usage patterns are affected by the v6 release.

## Files changed

17 source files updated, 26 occurrences replaced:

**Composite actions (6 files, 6 occurrences):**
- `pr-review/action.yml`
- `tag-claude/action.yml`
- `apply-fix/action.yml`
- `lint-apply/action.yml`
- `lint-diagnose/action.yml`
- `lint-failure/action.yml`

**Workflow files (11 files, 20 occurrences):**
- `.github/workflows/runtime-build.yml` (8 occurrences)
- `.github/workflows/test.yml` (2 occurrences)
- `.github/workflows/claude-tag-respond.yml` (2 occurrences)
- `.github/workflows/claude-ci-failure.yml`
- `.github/workflows/marker-emission-aggregate.yml`
- `.github/workflows/overlay-smoke.yml`
- `.github/workflows/runtime-rollback.yml`
- `.github/workflows/runtime-check-private-freshness.yml`
- `.github/workflows/apply-fix.yml`
- `.github/workflows/ci-failure.yaml`
- `.github/workflows/lint.yml`

Plan files (`docs/superpowers/plans/phase-1-scaffold.md`, `phase-2-base-image.md`, `phase-4-router.md`) verified to remain at `@v5` — these are historical scaffolding records and are excluded from the bump per task scope.

## Test plan

- [x] `actionlint` passes locally on all 11 modified workflow files (exit 0, no output)
- [ ] CI lint workflow (`.github/workflows/lint.yml`) must pass on this PR
- [ ] Dogfooded `claude-pr-review` job must succeed on this PR
- [ ] `runtime-build` job must succeed (triggered by `runtime/**` path — not touched here, but verifies the checkout step works in container context)

Closes #231

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_