### PR TITLE
fix(runtime): install baked persona at $HOME/.claude/CLAUDE.md for runtime CLI

### DIFF
--- a/.github/workflows/claude-ci-failure.yml
+++ b/.github/workflows/claude-ci-failure.yml
@@ -127,6 +127,23 @@ jobs:
             --jq '[.[] | {filename: .filename, patch: .patch}]' \
             | head -c 8000 > /tmp/pr_diff.json
 
+      - name: Install persona for claude-code-action CLI
+        shell: bash
+        run: |
+          # GitHub Actions overrides HOME=/github/home in container jobs, discarding
+          # the image's baked HOME=/opt/claude. The fresh CLI installed by
+          # claude-code-action@v1 reads its user-level CLAUDE.md from
+          # $HOME/.claude/CLAUDE.md — a path that does not exist by default.
+          # Copy the baked persona to where the runtime CLI looks.
+          # Tracking: https://github.com/glitchwerks/github-actions/issues/242
+          if [ -f /opt/claude/.claude/CLAUDE.md ]; then
+            mkdir -p "$HOME/.claude"
+            cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
+            echo "Persona installed: $(wc -l < "$HOME/.claude/CLAUDE.md") lines from /opt/claude/.claude/CLAUDE.md"
+          else
+            echo "::warning::No baked persona at /opt/claude/.claude/CLAUDE.md — running without overlay persona"
+          fi
+
       - name: Diagnose failure and optionally apply fix
         uses: anthropics/claude-code-action@v1
         with:

--- a/.github/workflows/claude-tag-respond.yml
+++ b/.github/workflows/claude-tag-respond.yml
@@ -203,6 +203,23 @@ jobs:
         shell: bash
         run: echo "RUN_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
 
+      - name: Install persona for claude-code-action CLI
+        shell: bash
+        run: |
+          # GitHub Actions overrides HOME=/github/home in container jobs, discarding
+          # the image's baked HOME=/opt/claude. The fresh CLI installed by
+          # claude-code-action@v1 reads its user-level CLAUDE.md from
+          # $HOME/.claude/CLAUDE.md — a path that does not exist by default.
+          # Copy the baked persona to where the runtime CLI looks.
+          # Tracking: https://github.com/glitchwerks/github-actions/issues/242
+          if [ -f /opt/claude/.claude/CLAUDE.md ]; then
+            mkdir -p "$HOME/.claude"
+            cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
+            echo "Persona installed: $(wc -l < "$HOME/.claude/CLAUDE.md") lines from /opt/claude/.claude/CLAUDE.md"
+          else
+            echo "::warning::No baked persona at /opt/claude/.claude/CLAUDE.md — running without overlay persona"
+          fi
+
       - uses: anthropics/claude-code-action@v1
         env:
           # Surfaces the router's mode decision to the verb-specific overlay

--- a/lint-diagnose/action.yml
+++ b/lint-diagnose/action.yml
@@ -106,6 +106,23 @@ runs:
           --jq '[.[] | {filename: .filename, patch: .patch}] | .[0:30]' \
           > /tmp/pr_diff.json
 
+    - name: Install persona for claude-code-action CLI
+      shell: bash
+      run: |
+        # GitHub Actions overrides HOME=/github/home in container jobs, discarding
+        # the image's baked HOME=/opt/claude. The fresh CLI installed by
+        # claude-code-action@v1 reads its user-level CLAUDE.md from
+        # $HOME/.claude/CLAUDE.md — a path that does not exist by default.
+        # Copy the baked persona to where the runtime CLI looks.
+        # Tracking: https://github.com/glitchwerks/github-actions/issues/242
+        if [ -f /opt/claude/.claude/CLAUDE.md ]; then
+          mkdir -p "$HOME/.claude"
+          cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
+          echo "Persona installed: $(wc -l < "$HOME/.claude/CLAUDE.md") lines from /opt/claude/.claude/CLAUDE.md"
+        else
+          echo "::warning::No baked persona at /opt/claude/.claude/CLAUDE.md — running without overlay persona"
+        fi
+
     - name: Diagnose lint failure
       id: claude-diagnose
       uses: anthropics/claude-code-action@v1

--- a/lint-failure/action.yml
+++ b/lint-failure/action.yml
@@ -106,6 +106,23 @@ runs:
           --jq '[.[] | {filename: .filename, patch: .patch}] | .[0:30]' \
           > /tmp/pr_diff.json
 
+    - name: Install persona for claude-code-action CLI
+      shell: bash
+      run: |
+        # GitHub Actions overrides HOME=/github/home in container jobs, discarding
+        # the image's baked HOME=/opt/claude. The fresh CLI installed by
+        # claude-code-action@v1 reads its user-level CLAUDE.md from
+        # $HOME/.claude/CLAUDE.md — a path that does not exist by default.
+        # Copy the baked persona to where the runtime CLI looks.
+        # Tracking: https://github.com/glitchwerks/github-actions/issues/242
+        if [ -f /opt/claude/.claude/CLAUDE.md ]; then
+          mkdir -p "$HOME/.claude"
+          cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
+          echo "Persona installed: $(wc -l < "$HOME/.claude/CLAUDE.md") lines from /opt/claude/.claude/CLAUDE.md"
+        else
+          echo "::warning::No baked persona at /opt/claude/.claude/CLAUDE.md — running without overlay persona"
+        fi
+
     - name: Diagnose lint failure and optionally apply fix
       uses: anthropics/claude-code-action@v1
       with:

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -177,6 +177,23 @@ runs:
       shell: bash
       run: echo "REVIEW_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
 
+    - name: Install persona for claude-code-action CLI
+      shell: bash
+      run: |
+        # GitHub Actions overrides HOME=/github/home in container jobs, discarding
+        # the image's baked HOME=/opt/claude. The fresh CLI installed by
+        # claude-code-action@v1 reads its user-level CLAUDE.md from
+        # $HOME/.claude/CLAUDE.md — a path that does not exist by default.
+        # Copy the baked persona to where the runtime CLI looks.
+        # Tracking: https://github.com/glitchwerks/github-actions/issues/242
+        if [ -f /opt/claude/.claude/CLAUDE.md ]; then
+          mkdir -p "$HOME/.claude"
+          cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
+          echo "Persona installed: $(wc -l < "$HOME/.claude/CLAUDE.md") lines from /opt/claude/.claude/CLAUDE.md"
+        else
+          echo "::warning::No baked persona at /opt/claude/.claude/CLAUDE.md — running without overlay persona"
+        fi
+
     - uses: anthropics/claude-code-action@v1
       id: claude-review
       if: steps.authz.outputs.skip != 'true' && steps.size-check.outputs.skip != 'true'

--- a/tag-claude/action.yml
+++ b/tag-claude/action.yml
@@ -93,6 +93,24 @@ runs:
       shell: bash
       run: echo "RUN_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
 
+    - name: Install persona for claude-code-action CLI
+      if: steps.authz.outputs.authorized == 'true'
+      shell: bash
+      run: |
+        # GitHub Actions overrides HOME=/github/home in container jobs, discarding
+        # the image's baked HOME=/opt/claude. The fresh CLI installed by
+        # claude-code-action@v1 reads its user-level CLAUDE.md from
+        # $HOME/.claude/CLAUDE.md — a path that does not exist by default.
+        # Copy the baked persona to where the runtime CLI looks.
+        # Tracking: https://github.com/glitchwerks/github-actions/issues/242
+        if [ -f /opt/claude/.claude/CLAUDE.md ]; then
+          mkdir -p "$HOME/.claude"
+          cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
+          echo "Persona installed: $(wc -l < "$HOME/.claude/CLAUDE.md") lines from /opt/claude/.claude/CLAUDE.md"
+        else
+          echo "::warning::No baked persona at /opt/claude/.claude/CLAUDE.md — running without overlay persona"
+        fi
+
     - uses: anthropics/claude-code-action@v1
       if: steps.authz.outputs.authorized == 'true'
       with:


### PR DESCRIPTION
## Root cause

GitHub Actions unconditionally overrides `HOME=/github/home` when starting any container job, discarding the `HOME=/opt/claude` baked into the runtime overlay images. The fresh Claude CLI installed by `claude-code-action@v1` then reads its user-level `CLAUDE.md` from `$HOME/.claude/CLAUDE.md` — which resolves to `/github/home/.claude/CLAUDE.md`, a path that never exists.

Net effect: **the overlay personas have never actually been the system prompt at runtime since container jobs were introduced.** The `marker_missing` failures in the shadow quality-gate are the first observable signal — the review persona that instructs Claude to emit structured markers was silently absent from every run.

Full diagnosis with evidence: https://github.com/glitchwerks/github-actions/issues/242#issuecomment-4407557106

## Fix

Add a `Install persona for claude-code-action CLI` pre-step immediately before every `claude-code-action@v1` invocation. The step copies `/opt/claude/.claude/CLAUDE.md` → `$HOME/.claude/CLAUDE.md`. An `if [ -f ... ]` guard makes it a safe no-op on non-container paths (legacy `apply-fix.yml` etc.) where the baked persona does not exist.

## Files modified (6)

**Composite actions** (4-space indent under `runs.steps:`):
- `pr-review/action.yml`
- `lint-failure/action.yml`
- `lint-diagnose/action.yml`
- `tag-claude/action.yml`

**Reusable workflows that invoke `claude-code-action@v1` directly** (6-space indent under `jobs.<id>.steps:`):
- `.github/workflows/claude-ci-failure.yml`
- `.github/workflows/claude-tag-respond.yml`

Not edited: `ci-failure.yaml` (legacy, not container-pinned), `apply-fix/action.yml` (no `claude-code-action@v1` invocation).

## Diff stat

```
6 files changed, 103 insertions(+)
```

## Test plan

- [ ] CI lint (`actionlint`) passes on this PR
- [ ] After merge, trigger a PR review on siege-web and confirm the sticky comment includes the structured marker (`<!-- claude-review-outcome: ... -->`) — indicating the review overlay persona was active
- [ ] Shadow quality-gate status (`claude-pr-review/quality-gate-shadow`) transitions from `marker_missing` → `agree:clean` or `agree:blocking`

Closes #242

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_