### PR TITLE
fix(pr-review): skip resolution-narration lines in severity grep (#248)

### DIFF
--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -284,7 +284,13 @@ runs:
         # - Plain "MAJOR" / "BLOCKING" require markdown bold to avoid matching code
         #   snippets, prose, or unrelated tokens (SUBMAJOR, MAJOR_VERSION, UNBLOCKING).
         # Regex sourced from lib/severity-regex.sh (shared with synthesis and shadow gate).
-        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
+        # Pre-filter: drop lines containing the resolution checkmark (✅) before the
+        # severity grep. On incremental (multi-pass) reviews the persona narrates
+        # resolved findings as `#### ✅ 🔴 Critical (BLOCKING) - FIXED` — the severity
+        # token is identical to a fresh finding, but the checkmark distinguishes
+        # resolved-narration from open findings. Without this pre-filter, the gate
+        # blocks PRs whose findings are all fixed (issue #248).
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -v '✅' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
 
         echo "Quality gate scan: $BLOCKER_HITS marker(s) matched in latest sticky comment"
 
@@ -357,10 +363,16 @@ runs:
         # Count per-bucket using grep -oE | wc -l (counts matches, not lines).
         # grep -cE would count lines; a single line containing two severity tokens
         # would count as 1 — grep -oE | wc -l counts each token individually.
-        CRITICAL=$(printf '%s' "$BODY" | grep -oE "$SEVERITY_CRITICAL_RE" | wc -l || true)
-        HIGH=$(printf '%s' "$BODY"     | grep -oE "$SEVERITY_HIGH_RE"     | wc -l || true)
-        MEDIUM=$(printf '%s' "$BODY"   | grep -oE "$SEVERITY_MEDIUM_RE"   | wc -l || true)
-        LOW=$(printf '%s' "$BODY"      | grep -oE "$SEVERITY_LOW_RE"      | wc -l || true)
+        # Pre-filter `grep -v '✅'` drops resolution-narration lines (e.g.
+        # `#### ✅ 🔴 Critical (BLOCKING) - FIXED`) so resolved findings on
+        # incremental reviews don't inflate the synthesized counts (issue #248).
+        # Same pre-filter applies in the authoritative and shadow gate steps;
+        # all three callsites must stay in sync.
+        OPEN_BODY=$(printf '%s' "$BODY" | grep -v '✅' || true)
+        CRITICAL=$(printf '%s' "$OPEN_BODY" | grep -oE "$SEVERITY_CRITICAL_RE" | wc -l || true)
+        HIGH=$(printf '%s' "$OPEN_BODY"     | grep -oE "$SEVERITY_HIGH_RE"     | wc -l || true)
+        MEDIUM=$(printf '%s' "$OPEN_BODY"   | grep -oE "$SEVERITY_MEDIUM_RE"   | wc -l || true)
+        LOW=$(printf '%s' "$OPEN_BODY"      | grep -oE "$SEVERITY_LOW_RE"      | wc -l || true)
 
         # Defensive synthesis: refuse to post 0/0/0/0 unless a corroboration signal
         # confirms the LLM performed substantive analysis.
@@ -448,7 +460,10 @@ runs:
 
         # --- Prose-regex result (sourced from lib/severity-regex.sh) ----------------
         # Regex sourced above; $SEVERITY_BLOCKER_RE is the combined blocker class.
-        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
+        # `grep -v '✅'` drops resolution-narration lines so resolved findings
+        # on incremental reviews don't inflate the prose hit count. Must stay
+        # in sync with the authoritative gate step's identical pre-filter (#248).
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -v '✅' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
         if [ "$BLOCKER_HITS" -gt "0" ]; then
           PROSE_RESULT="blocking"
         else


### PR DESCRIPTION
## Summary

Hotfix for #248. On incremental (multi-pass) reviews the persona narrates resolved findings as `#### ✅ 🔴 Critical (BLOCKING) - FIXED`. The severity token on that line is byte-identical to a fresh finding, so the prose-regex on both gate steps counted resolved findings as live ones — blocking PRs whose findings were all fixed.

The fix inserts `grep -v '✅'` before the severity grep at all three callsites:

- Authoritative gate (`action.yml:287`)
- Shadow gate (`action.yml:451`)
- Synthesis step's per-bucket counts (`action.yml:360-369`, via a single `OPEN_BODY` intermediate filtered once and reused four times to keep the four bucket counts consistent)

`Closes #248`

## Diagnosis trail

Diagnosis: `glitchwerks/github-actions` issue #248. Reproduction case: `glitchwerks/claude-configs` PR #466 run id `25581406480`.

The bug was confirmed by:

1. Pulling Pass 2's run log: gate fired `failure` at 21:56:57Z; synthesis ran *after* at 21:56:58Z. The gate's `failure` was caused by the prose-regex on Pass 2's body, not by the synthesized marker.
2. Inspecting comment 4410134632's body: a single line `#### ✅ 🔴 Critical (BLOCKING) - FIXED` produced `BLOCKER_HITS=1`.
3. Confirming Pass 1 (4410111162) and Pass 2 (4410134632) are distinct comments, not the same comment edited in place. Sticky-accumulation hypothesis ruled out.

## Regression sanity-checks (locally verified before push)

| Scenario | Body shape | Expected | Got |
|---|---|---|---|
| Pass 1 fresh critical | `#### 🔴 Critical (BLOCKING)` (no checkmark) | `BLOCKER_HITS=1` (block) | 1 ✅ |
| Pass 2 all-resolved (the bug) | three `#### ✅ ... - FIXED` headers | `BLOCKER_HITS=0` (clear) | 0 ✅ |
| Pass 2 mixed (1 new critical + 1 resolved) | one fresh `#### 🔴 Critical (BLOCKING)` + one `#### ✅ ...` | `BLOCKER_HITS=1` (block) | 1 ✅ |
| Synthesis per-bucket on Pass 2 all-resolved | three resolution headers | `0/0/0/0` | `0/0/0/0` ✅ |

## What this PR does NOT change

The persona contract (`runtime/overlays/review/CLAUDE.md` lines ~110–164) still allows the LLM to emit a marker with cumulative counts on incremental reviews. When that happens, the synthesis step's `grep -qF '<!-- claude-pr-review-summary-v1'` skip-guard correctly defers to the LLM's counts — meaning the LLM, not the regex, would still produce wrong totals.

A persona-side hardening (telling the persona that `findings.*` counts reflect currently-open findings, not lifetime) is the natural follow-up. **It is not in this PR** because it requires a runtime-overlay rebuild + image promote + workflow digest bump (the same multi-step shipping flow we just used for v2.5.0). The regex fix in this PR is sufficient to unblock the gate on its own — the persona contribution to #248 only manifests when the LLM emits a marker AND that marker disagrees with the prose, AND the LLM-emitted-marker path is the only one that bypasses the synthesis step's regex correction.

A follow-up issue should track the persona hardening separately. (See `runtime/overlays/review/CLAUDE.md` and the v2.5.0 release notes for the layered-fix architecture.)

## Verification status

The dogfood `review` job triggered on this PR runs `@v2` (which currently floats to v2.5.0 — the broken version). It is **non-signal** for verifying this fix per CLAUDE.md's dogfooding limitation.

Authoritative verification post-merge:

- [x] Local sanity-checks against four scenarios — pass.
- [ ] Cut `v2.5.1` + move `v2`, then re-run `claude-configs#466` (push an empty commit to trigger a fresh review). Expect `quality-gate` to clear with `success` (label `agree:clean`) and the synthesis log line `Marker synthesized and appended: critical=0 high=0 medium=0 low=0`.
- [ ] Confirm fresh-finding gate behavior is unchanged on the next single-pass review (e.g., the next siege-web PR review with real findings).

## Test plan

- [x] actionlint: composite action files are out of CI scan scope; CI's `actionlint` job continues to scan only `.github/workflows/*.yml`. No new warnings.
- [x] Manual regex verification across four scenarios per the table above.
- [ ] Post-merge: cut v2.5.1, move `v2`, verify on `claude-configs#466`.

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_
