### PR TITLE
fix(pr-review): expand severity-grep filter to cover ADDRESSED/RESOLVED suffixes (#257)

### DIFF
--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -379,13 +379,15 @@ runs:
         # - Plain "MAJOR" / "BLOCKING" require markdown bold to avoid matching code
         #   snippets, prose, or unrelated tokens (SUBMAJOR, MAJOR_VERSION, UNBLOCKING).
         # Regex sourced from lib/severity-regex.sh (shared with synthesis and shadow gate).
-        # Pre-filter: drop lines containing the resolution checkmark (✅) before the
-        # severity grep. On incremental (multi-pass) reviews the persona narrates
-        # resolved findings as `#### ✅ 🔴 Critical (BLOCKING) - FIXED` — the severity
-        # token is identical to a fresh finding, but the checkmark distinguishes
-        # resolved-narration from open findings. Without this pre-filter, the gate
-        # blocks PRs whose findings are all fixed (issue #248).
-        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -v '✅' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
+        # Pre-filter: drop resolution-narration lines before the severity grep.
+        # On incremental (multi-pass) reviews the persona may narrate resolved
+        # findings in two styles: (a) `#### ✅ 🔴 Critical (BLOCKING) - FIXED`
+        # (checkmark on same line — covered by ✅ filter, issue #248); or
+        # (b) a `### ✅` section header followed by per-finding lines ending in
+        # `— **FIXED**`/`**ADDRESSED**`/`**RESOLVED**` (bold markdown suffix —
+        # covered by the extended regex, issue #257).
+        # Without this pre-filter, the gate blocks PRs whose findings are all fixed.
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
 
         echo "Quality gate scan: $BLOCKER_HITS marker(s) matched in latest sticky comment"
 
@@ -458,12 +460,15 @@ runs:
         # Count per-bucket using grep -oE | wc -l (counts matches, not lines).
         # grep -cE would count lines; a single line containing two severity tokens
         # would count as 1 — grep -oE | wc -l counts each token individually.
-        # Pre-filter `grep -v '✅'` drops resolution-narration lines (e.g.
-        # `#### ✅ 🔴 Critical (BLOCKING) - FIXED`) so resolved findings on
+        # Pre-filter drops resolution-narration lines so resolved findings on
         # incremental reviews don't inflate the synthesized counts (issue #248).
+        # Expanded in #257: also drop lines ending in **FIXED**, **ADDRESSED**,
+        # or **RESOLVED** (bold markdown) — the persona's terminal suffix on
+        # two-level narration structures where the ✅ appears on a section header
+        # rather than on the same line as the severity token.
         # Same pre-filter applies in the authoritative and shadow gate steps;
         # all three callsites must stay in sync.
-        OPEN_BODY=$(printf '%s' "$BODY" | grep -v '✅' || true)
+        OPEN_BODY=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*' || true)
         CRITICAL=$(printf '%s' "$OPEN_BODY" | grep -oE "$SEVERITY_CRITICAL_RE" | wc -l || true)
         HIGH=$(printf '%s' "$OPEN_BODY"     | grep -oE "$SEVERITY_HIGH_RE"     | wc -l || true)
         MEDIUM=$(printf '%s' "$OPEN_BODY"   | grep -oE "$SEVERITY_MEDIUM_RE"   | wc -l || true)
@@ -558,10 +563,12 @@ runs:
 
         # --- Prose-regex result (sourced from lib/severity-regex.sh) ----------------
         # Regex sourced above; $SEVERITY_BLOCKER_RE is the combined blocker class.
-        # `grep -v '✅'` drops resolution-narration lines so resolved findings
-        # on incremental reviews don't inflate the prose hit count. Must stay
-        # in sync with the authoritative gate step's identical pre-filter (#248).
-        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -v '✅' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
+        # Pre-filter drops resolution-narration lines so resolved findings
+        # on incremental reviews don't inflate the prose hit count. Expanded
+        # in #257 to also cover **FIXED**/**ADDRESSED**/**RESOLVED** suffixes
+        # (bold markdown). Must stay in sync with the authoritative gate step
+        # and the synthesis pre-filter (#248, #257).
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
         if [ "$BLOCKER_HITS" -gt "0" ]; then
           PROSE_RESULT="blocking"
         else

--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -385,9 +385,11 @@ runs:
         # (checkmark on same line — covered by ✅ filter, issue #248); or
         # (b) a `### ✅` section header followed by per-finding lines ending in
         # `— **FIXED**`/`**ADDRESSED**`/`**RESOLVED**` (bold markdown suffix —
-        # covered by the extended regex, issue #257).
+        # covered by the extended regex, issue #257). The pattern is anchored to
+        # end-of-line (\s*$) so it only matches the persona's actual terminal suffix
+        # and does not false-positive-suppress findings that mention FIXED mid-line.
         # Without this pre-filter, the gate blocks PRs whose findings are all fixed.
-        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*\s*$' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
 
         echo "Quality gate scan: $BLOCKER_HITS marker(s) matched in latest sticky comment"
 
@@ -465,10 +467,12 @@ runs:
         # Expanded in #257: also drop lines ending in **FIXED**, **ADDRESSED**,
         # or **RESOLVED** (bold markdown) — the persona's terminal suffix on
         # two-level narration structures where the ✅ appears on a section header
-        # rather than on the same line as the severity token.
+        # rather than on the same line as the severity token. Pattern anchored to
+        # end-of-line (\s*$) to avoid false-positive suppression of findings that
+        # mention FIXED/ADDRESSED/RESOLVED bold mid-line (#258 review feedback).
         # Same pre-filter applies in the authoritative and shadow gate steps;
         # all three callsites must stay in sync.
-        OPEN_BODY=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*' || true)
+        OPEN_BODY=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*\s*$' || true)
         CRITICAL=$(printf '%s' "$OPEN_BODY" | grep -oE "$SEVERITY_CRITICAL_RE" | wc -l || true)
         HIGH=$(printf '%s' "$OPEN_BODY"     | grep -oE "$SEVERITY_HIGH_RE"     | wc -l || true)
         MEDIUM=$(printf '%s' "$OPEN_BODY"   | grep -oE "$SEVERITY_MEDIUM_RE"   | wc -l || true)
@@ -566,9 +570,11 @@ runs:
         # Pre-filter drops resolution-narration lines so resolved findings
         # on incremental reviews don't inflate the prose hit count. Expanded
         # in #257 to also cover **FIXED**/**ADDRESSED**/**RESOLVED** suffixes
-        # (bold markdown). Must stay in sync with the authoritative gate step
-        # and the synthesis pre-filter (#248, #257).
-        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
+        # (bold markdown). Anchored to end-of-line (\s*$) so only the persona's
+        # terminal suffix is suppressed, not mid-line occurrences (#258). Must stay
+        # in sync with the authoritative gate step and the synthesis pre-filter
+        # (#248, #257, #258).
+        BLOCKER_HITS=$(printf '%s' "$BODY" | grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*\s*$' | grep -E -c "$SEVERITY_BLOCKER_RE" || true)
         if [ "$BLOCKER_HITS" -gt "0" ]; then
           PROSE_RESULT="blocking"
         else


### PR DESCRIPTION
## Bug

The `grep -v '✅'` pre-filter introduced in #248 / #242 only stripped resolution-narration lines where the ✅ checkmark appeared **on the same line** as the severity token — e.g.:

```
#### ✅ 🔴 Critical (BLOCKING) - FIXED
```

The persona also uses a two-level narration structure where the ✅ appears on a **section header** and resolved findings appear as separate lines ending in a bold markdown suffix:

```
### ✅ Resolved Findings

- **Finding title** — **FIXED**
- **Another finding** — **ADDRESSED**
```

In this structure the per-finding lines contain the severity token but not the ✅ character, so they passed through the filter unmodified and triggered the quality gate on fully-resolved PRs. This was first observed in claude-configs#490.

## Fix

Expand the pre-filter from `grep -v '✅'` to:

```bash
# Before
grep -v '✅'

# After
grep -vE '✅|\*\*(FIXED|ADDRESSED|RESOLVED)\*\*'
```

The `\*\*(FIXED|ADDRESSED|RESOLVED)\*\*` alternative covers all three bold-markdown resolution suffixes the persona uses consistently as terminal markup on resolved findings. A genuine open finding will never contain these bold-wrapped words.

All three callsites that apply this filter are updated and kept in sync:
- Line ~390 — authoritative quality gate
- Line ~471 — synthesis pre-filter (`OPEN_BODY`)
- Line ~571 — shadow gate (prose-regex path)

Comment blocks at each callsite are also updated to document the two-style narration pattern and reference #257.

## Prior fixes in this chain

- #242 — structured severity marker synthesis from review prose
- #248 — initial `grep -v '✅'` pre-filter for resolution-narration lines
- #257 (this PR) — extend filter to cover two-level narration structure

## Test plan

- [ ] `actionlint` passes (CI will run on this PR)
- [ ] Manual re-test: request a Claude review on a PR that uses the `### ✅` section header + `— **FIXED**` per-finding narration structure; quality gate should report `success` rather than `failure`

> **Dogfooding note:** This repo's CI exercises the released `@v2` composite action, not this branch's code. Manual validation via an external consumer repo pointing at this branch is required to confirm the new filter path executes. See CLAUDE.md § "We dogfooded it" for the structural limitation.

Fixes #257

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_