### PR TITLE
fix(claude-command-router): use absolute ref for check-auth (#262)

### DIFF
--- a/claude-command-router/action.yml
+++ b/claude-command-router/action.yml
@@ -30,7 +30,7 @@ runs:
   steps:
     - name: Check authorization
       id: authz
-      uses: ./check-auth
+      uses: glitchwerks/github-actions/check-auth@v2
       with:
         authorized_users: ${{ inputs.authorized_users }}
 


### PR DESCRIPTION
## Problem

`claude-command-router/action.yml` referenced `check-auth` via a relative path:

```yaml
uses: ./check-auth
```

When an external consumer invokes `glitchwerks/github-actions/claude-command-router@v2` as a reusable workflow step, `actions/checkout@v4` puts the **consumer's** repo into the runner workspace. `./check-auth` then resolves into the consumer's tree — which has no such directory — and the action fails.

Real-world failure: https://github.com/glitchwerks/claude-configs/actions/runs/25617446089

This footgun is documented in this repo's own `CLAUDE.md` under "Why absolute refs, not relative paths" — composite actions calling sibling composite actions must use absolute refs.

## Fix

Changed the `uses:` reference to the absolute form:

```yaml
uses: glitchwerks/github-actions/check-auth@v2
```

GitHub resolves this directly from this library's tree regardless of what repo the consumer has checked out.

## Audit

Grepped all `action.yml` files in the repo for remaining `uses: ./` references. No other composite action files contain relative sibling references — this was the only instance.

Workflow files under `.github/workflows/` were excluded from flagging; relative `./` refs there (e.g. `apply-fix.yml` → `./apply-fix`) are correct because reusable workflows operate within a single checkout context.

## CI note

Due to the dogfooding limitation noted in `CLAUDE.md`, CI on this PR tests `check-auth` at the released `@v2` tag, not the branch's composite action changes. The bug only manifests when invoked from an external consumer repo. The fix is verified by inspection.

Closes #262

---

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_