### PR TITLE
fix(pr-review): extend overlay install to full tree; add ALLOWED_TOOLS Task+Skill (#259)

### DIFF
--- a/pr-review/action.yml
+++ b/pr-review/action.yml
@@ -243,21 +243,25 @@ runs:
       shell: bash
       run: echo "REVIEW_START_TIME=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_ENV"
 
-    - name: Install persona for claude-code-action CLI
+    - name: Install overlay tree for claude-code-action CLI
       shell: bash
       run: |
         # GitHub Actions overrides HOME=/github/home in container jobs, discarding
-        # the image's baked HOME=/opt/claude. The fresh CLI installed by
-        # claude-code-action@v1 reads its user-level CLAUDE.md from
-        # $HOME/.claude/CLAUDE.md — a path that does not exist by default.
-        # Copy the baked persona to where the runtime CLI looks.
-        # Tracking: https://github.com/glitchwerks/github-actions/issues/242
-        if [ -f /opt/claude/.claude/CLAUDE.md ]; then
+        # the image's baked HOME=/opt/claude. The CLI discovers $HOME/.claude/ which
+        # resolves to /github/home/.claude/ (empty) — agents/skills/plugins/hooks are
+        # all orphaned. Fix: copy the full baked overlay tree into $HOME/.claude/ so
+        # the CLI's user-level discovery finds the complete agent/skill/plugin set.
+        # CLAUDE.md copy is covered by this cp (superset of the old cp step).
+        # Tracking: https://github.com/glitchwerks/github-actions/issues/259
+        if [ -d /opt/claude/.claude ]; then
           mkdir -p "$HOME/.claude"
-          cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"
-          echo "Persona installed: $(wc -l < "$HOME/.claude/CLAUDE.md") lines from /opt/claude/.claude/CLAUDE.md"
+          cp -r /opt/claude/.claude/. "$HOME/.claude/"
+          agent_count=$(find "$HOME/.claude/agents" -name '*.md' 2>/dev/null | wc -l || echo 0)
+          skill_count=$(find "$HOME/.claude/skills" -type f 2>/dev/null | wc -l || echo 0)
+          plugin_count=$(find "$HOME/.claude/plugins" -type d -mindepth 1 -maxdepth 1 2>/dev/null | wc -l || echo 0)
+          echo "Overlay installed: agents=${agent_count} skills=${skill_count} plugins=${plugin_count}"
         else
-          echo "::warning::No baked persona at /opt/claude/.claude/CLAUDE.md — running without overlay persona"
+          echo "::warning::No baked overlay at /opt/claude/.claude — running without overlay tree"
         fi
 
     - name: Generate App token
@@ -291,7 +295,7 @@ runs:
         github_token: ${{ steps.token.outputs.value }}
         use_sticky_comment: true
         track_progress: true
-        claude_args: --max-turns ${{ env.EFFECTIVE_MAX_TURNS }} --model ${{ inputs.model }} --allowedTools "Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr view:*)"
+        claude_args: --max-turns ${{ env.EFFECTIVE_MAX_TURNS }} --model ${{ inputs.model }} --allowedTools "Bash(gh pr diff:*),Bash(gh pr review:*),Bash(gh pr view:*),Task,Skill"
         prompt: |
           Review the pull request in repository ${{ github.repository }} (#${{ github.event.pull_request.number }}).
 

--- a/runtime/scripts/smoke-test.sh
+++ b/runtime/scripts/smoke-test.sh
@@ -63,11 +63,13 @@ FILES_OUT=$(mktemp)
 SMOKE_OUT=$(mktemp)
 SMOKE_STDERR=$(mktemp)
 PERMS_STDERR=$(mktemp)
+REACH_OUT=$(mktemp)
+REACH_STDERR=$(mktemp)
 # Cumulative cleanup function — variables are interpolated at exit time, so
-# adding more temp files later (SMOKE_STDERR, PERMS_STDERR) is automatically
-# included as long as those vars are non-empty when the trap fires.
+# adding more temp files later is automatically included as long as those
+# vars are non-empty when the trap fires.
 cleanup() {
-  rm -f "$SMOKE_OUT" "${SMOKE_STDERR:-}" "${PERMS_STDERR:-}" "$FILES_OUT" 2>/dev/null
+  rm -f "$SMOKE_OUT" "${SMOKE_STDERR:-}" "${PERMS_STDERR:-}" "$FILES_OUT" "${REACH_OUT:-}" "${REACH_STDERR:-}" 2>/dev/null
 }
 trap cleanup EXIT
 
@@ -120,6 +122,30 @@ if [ "${#missing[@]}" -gt 0 ]; then
 fi
 
 echo "smoke-test: persona structural check OK (agents=$agent_count, skills=$skill_count, plugins=$plugin_count, all required files present)"
+
+# ---- (a.3) Reachability probe: overlay tree reachable via $HOME discovery ----
+# Validates that the cp -r step in pr-review/action.yml (issue #259) makes
+# baked agents discoverable when GHA overrides HOME to a fresh directory.
+echo "smoke-test: reachability probe..."
+if ! docker run --rm --user "$SMOKE_UID" \
+    -e HOME=/tmp/fake-home \
+    --entrypoint /bin/sh "$IMAGE" \
+    -c 'mkdir -p /tmp/fake-home/.claude && cp -r /opt/claude/.claude/. /tmp/fake-home/.claude/ && find /tmp/fake-home/.claude/agents -name "*.md" | wc -l' \
+    > "$REACH_OUT" 2>"$REACH_STDERR"; then
+  echo "ERROR reachability_probe_failed image=$IMAGE" >&2
+  cat "$REACH_STDERR" >&2
+  exit 1
+fi
+
+reach_agents=$(tr -d '[:space:]' < "$REACH_OUT")
+if [ "${reach_agents:-0}" = "0" ]; then
+  echo "ERROR reachability_zero_agents image=$IMAGE" >&2
+  echo "       After simulated GHA HOME override + cp -r, no agent *.md files found under \$HOME/.claude/agents." >&2
+  echo "       This means the overlay tree would be orphaned at job runtime." >&2
+  cat "$REACH_STDERR" >&2
+  exit 1
+fi
+echo "smoke-test: reachability probe OK (${reach_agents} agent files discoverable via simulated \$HOME)"
 
 # ---- (b) Inventory assertions (Phase 3+; skipped for base) -----------------
 # EXPECTED_FILE matcher contract (specified in Phase 2; consumed in Phase 3+):


### PR DESCRIPTION
## Summary

Fixes #259 — baked overlay agents/skills/plugins/hooks were orphaned at job runtime because GitHub Actions overrides `HOME=/github/home`, discarding the image's `ENV HOME=/opt/claude`. The CLI's user-level discovery looked at `/github/home/.claude/` (empty) instead of `/opt/claude/.claude/`.

The existing workaround in `pr-review/action.yml` copied only `CLAUDE.md` — this PR extends it to the full overlay tree and aligns `ALLOWED_TOOLS` so loaded agents can actually dispatch.

## Changes

### `pr-review/action.yml`

**Step rename + extension** (`Install persona for claude-code-action CLI` → `Install overlay tree for claude-code-action CLI`):
- Condition changed from `[ -f /opt/claude/.claude/CLAUDE.md ]` → `[ -d /opt/claude/.claude ]`
- Copy changed from `cp /opt/claude/.claude/CLAUDE.md "$HOME/.claude/CLAUDE.md"` → `cp -r /opt/claude/.claude/. "$HOME/.claude/"` (superset — CLAUDE.md copy is included)
- Log output now reports agent/skill/plugin counts installed
- `rsync` avoided intentionally — not in the overlay image's apt-get block; `cp -r` is POSIX-portable

**`ALLOWED_TOOLS` alignment** (line 298):
- Added `Task,Skill` to `--allowedTools` — without these, loaded agents cannot dispatch sub-agents or invoke skills even after the tree is reachable

### `runtime/scripts/smoke-test.sh`

**New section `(a.3) Reachability probe`** (inserted after the existing structural check):
- Simulates GHA HOME override (`-e HOME=/tmp/fake-home`) in a `docker run`
- Performs the same `mkdir -p + cp -r` the action step does
- Asserts at least one agent `*.md` file is discoverable under the simulated `$HOME/.claude/agents/`
- Fails with `ERROR reachability_zero_agents` if count is zero
- `REACH_OUT` / `REACH_STDERR` temp vars added at top; `cleanup()` extended to include them (no duplicate trap)

## Why `cp -r` not `rsync`

The overlay images install `git`, `curl`, `jq`, `unzip`, and `gh` via apt — `rsync` is not in the list. Using `rsync` would produce a silent `command not found` failure. `cp -r` is always present.

## Priority ordering

After the copy, overlay agents land at user-level (`$HOME/.claude/agents/`). The CLI discovery chain is user > project. Consumer-repo `.claude/` is at project-level — overlay takes precedence. This is **correct** for the "different eyes" guarantee: the review overlay's `inquisitor` must load, not whatever agents the consumer happens to have.

## Test plan

- [ ] Actionlint passes on `pr-review/action.yml` (no structural YAML issues)
- [ ] `bash -n runtime/scripts/smoke-test.sh` passes (syntax clean)
- [ ] CI `lint.yml` green on this PR
- [ ] After merge: rebuild overlay images and run `overlay-smoke.yml` — new reachability probe (`a.3`) should pass for all three overlays
- [ ] After overlay rebuild: open a test PR against a consumer repo and confirm review comment includes output from a baked agent (not just persona CLAUDE.md)

## Unblocks

- #185 observation window reset (post-#259 + overlay rebuild, counters restart)
- Shadow-gate promotion data collection resumes against the actual W3 agent set

🤖 _Generated by Claude Code on behalf of @cbeaulieu-gt_